### PR TITLE
Merge Support Page Additions Into Main CSS Repository For Publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 bower_components
 *.sublime-project
 *.sublime-workspace
+
+*.swp # Ignore VIM temp files.
+.*.swp

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -1,4 +1,3 @@
-<div style="font-size:larger;">
 <div class="section gradient-up" id="intro-section">
   <div class="inner-section">
     <div class="section-title">Student Health &amp; Support</div>
@@ -115,5 +114,4 @@
 
     </div>
   </div>
-</div>
 </div>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -1,3 +1,4 @@
+<div style="font-size:larger;">
 <div class="section gradient-up" id="intro-section">
   <div class="inner-section">
     <div class="section-title">Student Health &amp; Support</div>
@@ -7,14 +8,14 @@
       this page be as well-informed as possible. If you think something is
       missing, you can get in touch with someone on 
       <a href="/about">the committee</a>, or you can add the content yourself
-      and <a href="">file a pull request</a>. 
+      and <a href="https://github.com/cssbristol/cssbristol.github.io" target="_blank">file a pull request</a>. 
       </p>
       
       <p>
       While we sort this page out 
       though, you can use the 
-      <a href="https://www.bristolsu.org.uk/justask/welfare/mentalhealth/">Student Union's JustAsk service </a>, or the 
-      <a href="http://www.bristol.ac.uk/students/services/mental-health/">Student Health &amp; Counselling Services</a>
+      <a target="_blank" href="https://www.bristolsu.org.uk/justask/welfare/mentalhealth/">Student Union's JustAsk service </a>, or the 
+      <a target="_blank" href="http://www.bristol.ac.uk/students/services/mental-health/">Student Health &amp; Counselling Services</a>
       and they are equipped to handle just about everything and anything!
       </p>
     </div>
@@ -26,7 +27,15 @@
   <div class="inner-section">
     <div class="section-title">Who is this page for?</div>
     <div class="section-content clear">
-        Lorem ipsum doler set amet.
+        This page is for all Computer Science students (whether at
+        undergraduate, master student or post graduate level) at the University
+        of Bristol. It also serves for students on joint honours courses like
+        Computer Science and Electronics, or Computer Science and Maths. It
+        aims to hold all of the information we need on where to seek support
+        during our studdies. In the past, it has been difficult to know exactly
+        where to go if we have a problem that is effecting our studdies, but is
+        not strictly academic in nature. This page aims to solve that, and put
+        all of the resources in one place.
 
     </div>
   </div>
@@ -34,9 +43,65 @@
 
 <div class="section">
   <div class="inner-section">
-    <div class="section-title">How do I know if I need help?</div>
+    <div class="section-title">What sort of problems does this include?</div>
     <div class="section-content clear">
+        <p>
+        In short, anything that is having a negative impact on your ability
+        to study, or otherwise do the things you want to do. This might
+        include, but is definitely not limited to:
+        </p>
+
+        <ul>
+            <li>Family problems like a bereavement, or sepparation of parents.</li>
+            <li>Problems with flatmates or friends, whether in real life or
+                online in discussion forums like Facebook, Twitter, Yik-Yak
+                and Snapchat. It also covers problems working with other
+                people in group projects.</li>
+            <li>Struggling to cope with deadlines. This might be balancing you
+                effort between multiple assignments, or simply finding the
+                stress of it all is stopping you being as capable as you feel
+                you should be. We all get stressed, it is part of the course.
+                A certain amount of stress can be motivational, even healthy.
+                The moment it begins to effect your day to day happiness or
+                will and ability to function as a person, then it is a good
+                idea to seek help.</li>
+            <li>If you had a pre-existing problem when you arrived at 
+                university and want to know what support is available. This
+                might be a physical or mental illness, special requirements
+                for exams, or anything you have needed help for in the past. It
+                need not be something <i>official</i>, university can be a
+                good opportunity to seek help for a problem you've not looked 
+                to solve before.</li>
+            <li>Any sort of trouble with sexism, homophobia, racism, 
+                transphobia, ableism or discrimination of any kind. Whether you
+                experience this yourself, or as something you have witnessed as
+                a 3rd party.</li>
+        </ul>
+        
+        <p>
+        It is worth giving special mention to two subjects in particular. We 
+        do not hold them to be more or less important than others mentioned,
+        time has shown that they are encountered a disproportionate amount both
+        at Bristol, and in the wider Computer Science community.
+        </p>
+        
+        <p>
+        <b>Stress &amp; Mental Health</b><br/>
         Lorem ipsum doler set amet.
+        </p>
+        
+        <p>
+        <b>Nastiness In Online Discussion Spaces</b><br/>
+        Lorem ipsum doler set amet.
+        </p>
+
+        <p>
+        Again, none of this is supposed to be a definitive list. At the end of
+        the day, if you feel that your ability to study is being negatively
+        effected by something, then the best thing you can do is seek help as
+        soon as possible, and not bottle it up and hope it passes!
+        </p>
+
 
     </div>
   </div>
@@ -50,4 +115,5 @@
 
     </div>
   </div>
+</div>
 </div>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -75,7 +75,7 @@ Key Considerations:
         </p>
 
         <ul>
-            <li>Family problems like a bereavement, or sepparation of parents.</li>
+            <li>Family problems like a bereavement, or separation of parents.</li>
             <li>Problems with flatmates or friends, whether in real life or
                 online in discussion forums like Facebook, Twitter, Yik-Yak
                 and Snapchat. It also covers problems working with other
@@ -176,8 +176,8 @@ Key Considerations:
                 For most things, your personal tutor should be your first point
                 of contact. They can usually point you in the right direction
                 when it comes to seeking further help, and are best placed to
-                help with problems that are academic in nature like problems
-                with team mates or other courseworks. It is thier job to
+                help with problems that are academic in nature like friction 
+                with team mates or other coursework. It is their job to
                 fight your corner in all matters between yourself and the
                 department.
                 </p>
@@ -305,7 +305,7 @@ Key Considerations:
     disabled students. Disability Services supports students with a range of
     disabilities including but not limited to:
     <ul>
-        <li>Autism Spectrum Disorders/Asperger's Syndrome</li>
+        <li>Autism Spectrum Disorders/Aspergers Syndrome</li>
         <li>Dyslexia, Dyspraxia and other specific learning difficulties </li>
         <li>Mental health difficulties </li>
         <li>Mobility impairments</li>
@@ -369,7 +369,7 @@ Key Considerations:
                 <p>
                 Nightline are a confidential and anonymous chat service
                 for students at the University of Bristol. They are similar
-                to the samaritains, with trained staff who are there only to
+                to the samaritans, with trained staff who are there only to
                 listen and not to judge. They are open 8pm to 8am each night.
                 If you find yourself up at two in the morning still writing
                 code and struggling to cope, they are a wonderful friendly
@@ -397,7 +397,7 @@ Key Considerations:
             </div>
             <div class="support-list-content">
                 <p>
-The University of Bristol Multifaith Chaplaincy seeks to serve students and
+The University of Bristol Multi-faith Chaplaincy seeks to serve students and
 staff of all faiths and none by:
 <ul>
 <li>Providing opportunities to explore spirituality, faith and belief</li>
@@ -436,7 +436,7 @@ staff of all faiths and none by:
                 sex, consent, and clearing up myths and misunderstandings. If
                 you don't know what the fuss is about, want to understand more
                 about consent, or need support for yourself or a friend, then
-                the University can help. It is nothing to be embaressed about.
+                the University can help. It is nothing to be embarrassed about.
                 </p>
 
                 <a href="http://www.bristol.ac.uk/students/services/consent/">http://www.bristol.ac.uk/students/services/consent/</a>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -1,17 +1,53 @@
-<div class="section" id="intro-section">
+<div class="section gradient-up" id="intro-section">
   <div class="inner-section">
     <div class="section-title">Student Health &amp; Support</div>
     <div class="section-content clear">
       <p>
-      We are working hard in conjunction with the department to ensure that this page be as well-informed as possible, please check back soon!
+      We are working hard with the department to make sure
+      this page be as well-informed as possible. If you think something is
+      missing, you can get in touch with someone on 
+      <a href="/about">the committee</a>, or you can add the content yourself
+      and <a href="">file a pull request</a>. 
       </p>
+      
       <p>
-      For pressing issues, please refer to the following resources:
+      While we sort this page out 
+      though, you can use the 
+      <a href="https://www.bristolsu.org.uk/justask/welfare/mentalhealth/">Student Union's JustAsk service </a>, or the 
+      <a href="http://www.bristol.ac.uk/students/services/mental-health/">Student Health &amp; Counselling Services</a>
+      and they are equipped to handle just about everything and anything!
       </p>
-      <p>
-        <a href="http://www.bristol.ac.uk/students/services/mental-health/" target="_blank">University of Bristol Mental Health and Well-being</a><br />
-        <a href="https://www.bristolsu.org.uk/justask/welfare/mentalhealth/" target="_blank">Bristol Students' Union Health &amp; Wellbeing</a>
-      </p>
+    </div>
+    
+  </div>
+</div>
+
+<div class="section">
+  <div class="inner-section">
+    <div class="section-title">Who is this page for?</div>
+    <div class="section-content clear">
+        Lorem ipsum doler set amet.
+
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="inner-section">
+    <div class="section-title">How do I know if I need help?</div>
+    <div class="section-content clear">
+        Lorem ipsum doler set amet.
+
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="inner-section">
+    <div class="section-title">What help is on offer?</div>
+    <div class="section-content clear">
+        Lorem ipsum doler set amet.
+
     </div>
   </div>
 </div>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -202,7 +202,15 @@ Key Considerations:
                 University Student Health Service
             </div>
             <div class="support-list-content">
-                Lorem ipsum doler set amet.
+                <p>
+                The Student Health Service offer a full NHS General Practice
+                service for all University of Bristol students. They are the
+                best place to go for any sort of medical problems, mental
+                or physical.
+                </p>
+                <p>
+                <a href="http://www.bristol.ac.uk/students-health/">Student Health Services Website</a>.
+                </p>
             </div>
             <div class="support-use-case-list">
                 <div>Mental Health</div>
@@ -224,7 +232,23 @@ Key Considerations:
                 University Student Counselling Service
             </div>
             <div class="support-list-content">
-                Lorem ipsum doler set amet.
+                <p>
+                This is a dedicated service for students who need support or
+                counselling on a wide range of issues including mental health,
+                family, relationships and general wellbeing. They offer both
+                individual sessions, group sessions and workshops for specific 
+                problems. Group sessions &amp; workshops cover things like
+                specific illnesses, or methods of coping with stress and
+                other problems. The service is confidential and free to use.
+                </p>
+                <p>
+                <ul>
+                <li><a href="http://www.bristol.ac.uk/student-counselling/">Student Counselling Homepage</a></li>
+                <li><a href="http://www.bristol.ac.uk/student-counselling/services-offered/groups/">Support Groups Offered</a></li>
+                <li><a href="http://www.bristol.ac.uk/student-counselling/services-offered/workshops/">Workshops</a></li>
+                <li><a href="http://www.bristol.ac.uk/student-counselling/services-offered/one-to-one/">One To One Counselling</a></li>
+                </ul>
+                </p>
             </div>
             <div class="support-use-case-list">
                 <div>Mental Health Counselling</div>
@@ -246,7 +270,23 @@ Key Considerations:
                 University Disability Services
             </div>
             <div class="support-list-content">
-                Lorem ipsum doler set amet.
+                <p>
+    A confidential service providing information, advice and guidance to
+    prospective and current disabled students as well as to staff working with
+    disabled students. Disability Services supports students with a range of
+    disabilities including but not limited to:
+    <ul>
+        <li>Autism Spectrum Disorders/Asperger's Syndrome</li>
+        <li>Dyslexia, Dyspraxia and other specific learning difficulties </li>
+        <li>Mental health difficulties </li>
+        <li>Mobility impairments</li>
+        <li>Sensory impairments</li>
+        <li>Unseen disabilities like Epilepsy/HIV/AIDS/Chronic Fatigue</li>
+    </ul>
+                </p>
+                <p>
+                <a href="http://www.bristol.ac.uk/disability-services/">Disability Services Homepage</a>
+                </p>
             </div>
             <div class="support-use-case-list">
                 <div>Mental Health</div>
@@ -294,26 +334,22 @@ Key Considerations:
 
         <div class="support-list-element">
             <div class="support-list-title">
-                University Multi-faith Chaplaincy
-            </div>
-            <div class="support-list-content">
-                Lorem ipsum doler set amet.
-            </div>
-            <div class="support-use-case-list">
-                <div>Faith &amp; Spirituality</div>
-                <div>Wellbeing</div>
-                <div>Religious Advice</div>
-                <div>Friendship</div>
-                <div>Family</div>
-            </div>
-        </div>
-
-        <div class="support-list-element">
-            <div class="support-list-title">
                 Bristol Nightline
             </div>
             <div class="support-list-content">
-                Lorem ipsum doler set amet.
+                <p>
+                Nightline are a confidential and anonymous chat service
+                for students at the University of Bristol. They are similar
+                to the samaritains, with trained staff who are there only to
+                listen and not to judge. They are open 8pm to 8am each night.
+                If you find yourself up at two in the morning still writing
+                code and struggling to cope, they are a wonderful friendly
+                ear to your problems.
+                </p>
+                <p>
+                <a href="http://bristolnightline.org">Website</a><br/>
+                Telephone: 01179 266 266
+                </p>
             </div>
             <div class="support-use-case-list">
                 <div>Everything</div>
@@ -323,6 +359,35 @@ Key Considerations:
                 <div>Wellbeing</div>
                 <div>Stress</div>
                 <div>Anxiety</div>
+            </div>
+        </div>
+
+        <div class="support-list-element">
+            <div class="support-list-title">
+                University Multi-faith Chaplaincy
+            </div>
+            <div class="support-list-content">
+                <p>
+The University of Bristol Multifaith Chaplaincy seeks to serve students and
+staff of all faiths and none by:
+<ul>
+<li>Providing opportunities to explore spirituality, faith and belief</li>
+<li>Offering confidential personal support </li>
+<li>Giving religious advice and information</li>
+<li>Supporting the University as an institution </li>
+<li>Supporting local faith communities in their work with, and for, students and staff of the University.</li>
+</ul>
+                </p>
+                <p>
+                <a href="http://www.bristol.ac.uk/chaplaincy/">Chaplaincy Website</a>
+                </p>
+            </div>
+            <div class="support-use-case-list">
+                <div>Faith &amp; Spirituality</div>
+                <div>Wellbeing</div>
+                <div>Religious Advice</div>
+                <div>Friendship</div>
+                <div>Family</div>
             </div>
         </div>
         

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -28,7 +28,7 @@ Key Considerations:
     <div class="section-content clear">
       <p>
       We are working hard with the department to make sure
-      this page be as well-informed as possible. If you think something is
+      this page is as well-informed as possible. If you think something is
       missing, you can get in touch with someone on 
       <a href="/about">the committee</a>, or you can add the content yourself
       and <a href="https://github.com/cssbristol/cssbristol.github.io" target="_blank">file a pull request</a>. 
@@ -51,15 +51,14 @@ Key Considerations:
     <div class="section-title">Who is this page for?</div>
     <div class="section-content clear">
         This page is for all Computer Science students (whether at
-        undergraduate, master student or post graduate level) at the University
+        undergraduate, masters or post graduate level) at the University
         of Bristol. It also serves for students on joint honours courses like
         Computer Science and Electronics, or Computer Science and Maths. It
         aims to hold all of the information we need on where to seek support
         during our studdies. In the past, it has been difficult to know exactly
-        where to go if we have a problem that is effecting our studdies, but is
+        where to go if we have a problem that is effecting our studdies that is
         not strictly academic in nature. This page aims to solve that, and put
         all of the resources in one place.
-
     </div>
   </div>
 </div>
@@ -80,7 +79,7 @@ Key Considerations:
                 online in discussion forums like Facebook, Twitter, Yik-Yak
                 and Snapchat. It also covers problems working with other
                 people in group projects.</li>
-            <li>Struggling to cope with deadlines. This might be balancing you
+            <li>Struggling to cope with deadlines. This might be balancing your
                 effort between multiple assignments, or simply finding the
                 stress of it all is stopping you being as capable as you feel
                 you should be. We all get stressed, it is part of the course.
@@ -111,7 +110,7 @@ Key Considerations:
         <p>
         <b>Stress &amp; Mental Health</b><br/>
         Studying Computer Science is stressful. Multiple deadlines, exams and
-        group project all add up and take their toll. Many people are able to
+        group projects all add up and take their toll. Many people are able to
         cope with this stress, but for some people it starts to effect their
         health outside of University and their ability to function properly.
         For some, it can lead to bouts of depression, and other mental illness.
@@ -398,7 +397,7 @@ Key Considerations:
             <div class="support-list-content">
                 <p>
 The University of Bristol Multi-faith Chaplaincy seeks to serve students and
-staff of all faiths and none by:
+staff of any faith, or even none at all:
 <ul>
 <li>Providing opportunities to explore spirituality, faith and belief</li>
 <li>Offering confidential personal support </li>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -110,12 +110,41 @@ Key Considerations:
         
         <p>
         <b>Stress &amp; Mental Health</b><br/>
-        Lorem ipsum doler set amet.
+        Studying Computer Science is stressful. Multiple deadlines, exams and
+        group project all add up and take their toll. Many people are able to
+        cope with this stress, but for some people it starts to effect their
+        health outside of University and their ability to function properly.
+        For some, it can lead to bouts of depression, and other mental illness.
+        This has been a very taboo topic in the past, with a lot of
+        misunderstanding and grief as a result. It is important that we create
+        an environment within the computer science community at Bristol where
+        people feel able to ask for help without worrying about stigma and how
+        their peers will judge them. Similarly, if someone does open up to you,
+        it is important that you are comfortable in knowing how to respond!
+        There is a lot of advice on line on talking about mental health, and
+        how to seek help. This page won't seek to replicate that, but the
+        services listed below have lots of information on it.
         </p>
         
         <p>
         <b>Nastiness In Online Discussion Spaces</b><br/>
-        Lorem ipsum doler set amet.
+        We all know the internet has both wonderful corners and darker ones.
+        Above all, we know the importance of respecting each other online, and
+        not forgetting that there is a real human on the other end of a comment
+        thread. Occasionally this does get forgotten, and nastiness ensues. If
+        you ever feel uncomfortable in an online space or in person, then the
+        department, students union and university have guidelines on how to
+        deal with it. As a union affiliated society, CSS is bound by their safe
+        space policy. Such policies are often drastically misunderstood and end
+        up being ridiculed online.  BristolSU's 
+        <a href="https://www.bristolsu.org.uk/pageassets/activities/societies/roomandequipmentbookings/Safe-Space-Policy-motion.pdf">safe space policy can be read here</a>
+        so you know exactly what
+        it does and does not say. There are also some 
+        <a href="https://www.bristolsu.org.uk/pageassets/democracy/events/policy/SafeSpaceBestPracticeGuide-Edited.pdf">guidelines</a> available for
+        how to interpret the safe space policy in a sensible way.
+        Any problems you have yourself, or witness as
+        a 3rd party, can be raised with your personal tutor or the students
+        union.
         </p>
 
         <p>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -110,8 +110,33 @@
   <div class="inner-section">
     <div class="section-title">What help is on offer?</div>
     <div class="section-content clear">
-        Lorem ipsum doler set amet.
+        <table width="100%">
+        <tr>
+            <th style="width:30%">
+                Service
+            </th>
+            <th>
+                Helps With
+            </th>
+        </tr>
+        <tr>
+            <th>
+                Student Health Service
+            </th>
+            <td>
+                Lorem Ipsum Doler Set Amet.
+            </td>
+        </tr>
+        <tr>
+            <th>
+                Student Counselling Service
+            </th>
+            <td>
+                Lorem Ipsum Doler Set Amet.
+            </td>
+        </tr>
 
+        </table>
     </div>
   </div>
 </div>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -102,10 +102,10 @@ Key Considerations:
         </ul>
         
         <p>
-        It is worth giving special mention to two subjects in particular. We 
-        do not hold them to be more or less important than others mentioned,
-        time has shown that they are encountered a disproportionate amount both
-        at Bristol, and in the wider Computer Science community.
+        It is worth giving special mention to two subjects in particular. We do
+        not hold them to be more or less important than others mentioned, but
+        time has shown that they have been encountered a disproportionate
+        amount both at Bristol, and in the wider Computer Science community.
         </p>
         
         <p>
@@ -143,7 +143,20 @@ Key Considerations:
                 Personal Tutors
             </div>
             <div class="support-list-content">
-                Lorem ipsum doler set amet.
+                <p>
+                For most things, your personal tutor should be your first point
+                of contact. They can usually point you in the right direction
+                when it comes to seeking further help, and are best placed to
+                help with problems that are academic in nature like problems
+                with team mates or other courseworks. It is thier job to
+                fight your corner in all matters between yourself and the
+                department.
+                </p>
+                <p>
+                You should have been told who your personal tutor is, and
+                have met them! If for any reason you don't know who they
+                are, then you can find out by looking at your profile on
+                <a href="https://wwwa.fen.bris.ac.uk/coms/index.jsp">SAFE</a>.
             </div>
             <div class="support-use-case-list">
                 <div>Stress</div>
@@ -157,10 +170,22 @@ Key Considerations:
         
         <div class="support-list-element">
             <div class="support-list-title">
-                Year Tutor 
+                Senior Tutors
             </div>
             <div class="support-list-content">
-                Lorem ipsum doler set amet.
+                <p>
+                These tutors are "one up" from your personal tutor, and can
+                be turned to for problems that for whatever reason, you can't
+                solve with your personal tutor. These might be academic or
+                personal in nature.
+                </p>
+                <p>
+                According to the 2014/15 staff duties list, the three
+                senior tutors for the Computer Science department are
+                <a href="https://www.cs.bris.ac.uk/People/personal.jsp?key=4252">Peter Flach</a>, 
+                <a href="https://www.cs.bris.ac.uk/People/personal.jsp?key=4214">Steve Gregory</a> and 
+                <a href="https://www.cs.bris.ac.uk/People/personal.jsp?key=5293">Elizabeth Oswald</a>.
+                </p>
             </div>
             <div class="support-use-case-list">
                 <div>Stress</div>

--- a/src/app/components/support/supportView.html
+++ b/src/app/components/support/supportView.html
@@ -1,3 +1,27 @@
+<!--
+Rational behind this page
+-------------------------
+
+To provide as much information on the support avilable to students as possible
+in the most clear and concise way.
+
+Key Considerations:
+- Provide information on the situations each service is equipped to deal with.
+- Contact information: email, web, phone, address.
+- Many students do not speak english as their first language. Keep the
+  sentence construction and vocabulary clear and easy to parse.
+- Aim for inclusivity of information, rather than only the most common problems
+- Some of this content might make people feel uncomfortable to see. This might
+  be because they find the topic awkward, have been personally affected by it,
+  or are sceptical about the severity / worth / importance of the problem.
+  Any and all steps should be taken to make people feel comfortable with
+  the content, and explain why it is nessecary.
+- While the page aims to have as much information is possible, make sure it is
+  all framed in a way such that it's relevance is immediately clear to
+  computer science students.
+
+-->
+
 <div class="section gradient-up" id="intro-section">
   <div class="inner-section">
     <div class="section-title">Student Health &amp; Support</div>
@@ -14,8 +38,8 @@
       While we sort this page out 
       though, you can use the 
       <a target="_blank" href="https://www.bristolsu.org.uk/justask/welfare/mentalhealth/">Student Union's JustAsk service </a>, or the 
-      <a target="_blank" href="http://www.bristol.ac.uk/students/services/mental-health/">Student Health &amp; Counselling Services</a>
-      and they are equipped to handle just about everything and anything!
+      <a target="_blank" href="http://www.bristol.ac.uk/students/services/mental-health/">Student Health &amp; Counselling Services</a>.
+      They are equipped to handle just about everything and anything!
       </p>
     </div>
     
@@ -109,34 +133,237 @@
 <div class="section">
   <div class="inner-section">
     <div class="section-title">What help is on offer?</div>
-    <div class="section-content clear">
-        <table width="100%">
-        <tr>
-            <th style="width:30%">
-                Service
-            </th>
-            <th>
-                Helps With
-            </th>
-        </tr>
-        <tr>
-            <th>
-                Student Health Service
-            </th>
-            <td>
-                Lorem Ipsum Doler Set Amet.
-            </td>
-        </tr>
-        <tr>
-            <th>
-                Student Counselling Service
-            </th>
-            <td>
-                Lorem Ipsum Doler Set Amet.
-            </td>
-        </tr>
 
-        </table>
+    <!-- This whole list should really be yaml and re-generated automatically,
+         but I don't know how that bit works, so I am just writing it so it
+         is there to be read. The back end can be changed later! -->
+        
+        <div class="support-list-element">
+            <div class="support-list-title">
+                Personal Tutors
+            </div>
+            <div class="support-list-content">
+                Lorem ipsum doler set amet.
+            </div>
+            <div class="support-use-case-list">
+                <div>Stress</div>
+                <div>Academic Support</div>
+                <div>Group Work</div>
+                <div>Peer Problems</div>
+                <div>Staff Problems</div>
+                <div>Extenuating Circumstances</div>
+            </div>
+        </div>
+        
+        <div class="support-list-element">
+            <div class="support-list-title">
+                Year Tutor 
+            </div>
+            <div class="support-list-content">
+                Lorem ipsum doler set amet.
+            </div>
+            <div class="support-use-case-list">
+                <div>Stress</div>
+                <div>Academic Support</div>
+                <div>Group Work</div>
+                <div>Peer Problems</div>
+                <div>Staff Problems</div>
+                <div>Extenuating Circumstances</div>
+            </div>
+        </div>
+        
+        <div class="support-list-element">
+            <div class="support-list-title">
+                University Student Health Service
+            </div>
+            <div class="support-list-content">
+                Lorem ipsum doler set amet.
+            </div>
+            <div class="support-use-case-list">
+                <div>Mental Health</div>
+                <div>Prescription Medication</div>
+                <div>Depression</div>
+                <div>Eating Disorders</div>
+                <div>Injuries</div>
+                <div>Sexual Health</div>
+                <div>Physical Illness</div>
+                <div>Addiction</div>
+                <div>Violence</div>
+                <div>Extenuating Circumstances</div>
+                <div>Crisis Support</div>
+            </div>
+        </div>
+
+        <div class="support-list-element">
+            <div class="support-list-title">
+                University Student Counselling Service
+            </div>
+            <div class="support-list-content">
+                Lorem ipsum doler set amet.
+            </div>
+            <div class="support-use-case-list">
+                <div>Mental Health Counselling</div>
+                <div>Wellbeing</div>
+                <div>Stress</div>
+                <div>Depression</div>
+                <div>Anxiety</div>
+                <div>Eating Disorders</div>
+                <div>Relationships</div>
+                <div>Grief</div>
+                <div>Extenuating Circumstances</div>
+                <div>Addiction</div>
+                <div>Violence</div>
+            </div>
+        </div>
+
+        <div class="support-list-element">
+            <div class="support-list-title">
+                University Disability Services
+            </div>
+            <div class="support-list-content">
+                Lorem ipsum doler set amet.
+            </div>
+            <div class="support-use-case-list">
+                <div>Mental Health</div>
+                <div>Chronic Physical Illness</div>
+                <div>Physical Disability</div>
+                <div>Mobility Impairments</div>
+                <div>Sensory Impairments</div>
+                <div>Learning Impairments</div>
+            </div>
+        </div>
+        
+        <div class="support-list-element">
+            <div class="support-list-title">
+                Bristol SU JustAsk!
+            </div>
+            <div class="support-list-content">
+            <p>
+            JustAsk aims to be a one-stop shop for student support, signposting
+            students in the right direction where necessary but ensuring
+            support throughout. The service is free, confidential, impartial
+            and accessible to all students. With this in mind we have a range
+            of ways to get advice and support.
+            </p>
+            <p>
+            The Just Ask Office is located on the 3rd Floor of the Students’
+            Union main building on Queens Road in Clifton. Drop by to ask a
+            question or have a chat Monday-Friday from 10am-4pm. 
+            </p>
+            <a href="mailto:bristolsu-justask@bristol.ac.uk">bristolsu-justask@bristol.ac.uk</a><br/>
+            <a href="http://www.bristolsu.org.uk/justask/">http://www.bristolsu.org.uk/justask/</a>
+            </div>
+            <div class="support-use-case-list">
+                <div>Mental Health</div>
+                <div>Wellbeing</div>
+                <div>Support Groups</div>
+                <div>Law &amp; Money</div>
+                <div>Academic Problems</div>
+                <div>Sex</div>
+                <div>Consent</div>
+                <div>Crisis Support</div>
+                <div>Addiction</div>
+                <div>Violence</div>
+            </div>
+        </div>
+
+        <div class="support-list-element">
+            <div class="support-list-title">
+                University Multi-faith Chaplaincy
+            </div>
+            <div class="support-list-content">
+                Lorem ipsum doler set amet.
+            </div>
+            <div class="support-use-case-list">
+                <div>Faith &amp; Spirituality</div>
+                <div>Wellbeing</div>
+                <div>Religious Advice</div>
+                <div>Friendship</div>
+                <div>Family</div>
+            </div>
+        </div>
+
+        <div class="support-list-element">
+            <div class="support-list-title">
+                Bristol Nightline
+            </div>
+            <div class="support-list-content">
+                Lorem ipsum doler set amet.
+            </div>
+            <div class="support-use-case-list">
+                <div>Everything</div>
+                <div>Mental Health</div>
+                <div>Friendship</div>
+                <div>Family</div>
+                <div>Wellbeing</div>
+                <div>Stress</div>
+                <div>Anxiety</div>
+            </div>
+        </div>
+        
+        <!-- I anticipate this addition causing a certain amount of curiosity,
+             and questioning of its nessecity. Bottom line, if people don't
+             see the need, then they fall into one of two categories:
+             They can safely ignore this because to them it is "obvious", or
+             they are the people to whom the information would be the most
+             useful. -->
+        <div class="support-list-element">
+            <div class="support-list-title">
+                Sex &amp; Consent
+            </div>
+            <div class="support-list-content">
+                <p>
+                The University offers a lot of support and information around
+                sex, consent, and clearing up myths and misunderstandings. If
+                you don't know what the fuss is about, want to understand more
+                about consent, or need support for yourself or a friend, then
+                the University can help. It is nothing to be embaressed about.
+                </p>
+
+                <a href="http://www.bristol.ac.uk/students/services/consent/">http://www.bristol.ac.uk/students/services/consent/</a>
+            </div>
+            <div class="support-use-case-list">
+                <div>Sex</div>
+                <div>Consent</div>
+                <div>Crisis Support</div>
+            </div>
+        </div>
+
+        <div class="support-list-element">
+            <div class="support-list-title">
+                Vulnerable Students Support
+            </div>
+            <div class="support-list-content">
+                <p>
+                The Vulnerable Students' Support Service coordinates support
+                for our most vulnerable students who are, for whatever reason,
+                having difficulties functioning or continuing their studies
+                for non-academic reasons. They work closely with staff in
+                academic schools and students are supported by the most
+                appropriate service(s) from within Student Services
+                and/or from the NHS. Wherever possible they prefer to
+                provide pre-emptive support but are experienced in
+                managing crises.
+                </p>
+                <p>
+                Examples of support include cases of students with undiagnosed
+                or unsupported mental ill health including first incidents of
+                psychosis, the consequences of addiction, those who are
+                seemingly missing, victims of domestic violence, managing
+                family estrangements, and many more.
+                </p>
+
+                <a href="http://www.bristol.ac.uk/studentservices/vulnerablestudents/">http://www.bristol.ac.uk/studentservices/vulnerablestudents/</a>
+
+            </div>
+            <div class="support-use-case-list">
+                <div>Mental Health</div>
+                <div>Addiction</div>
+                <div>Violence</div>
+                <div>Family</div>
+                <div>Crisis Support</div>
+            </div>
+        </div>
     </div>
   </div>
 </div>

--- a/src/assets/styles/sections.less
+++ b/src/assets/styles/sections.less
@@ -421,3 +421,36 @@
     background-image: url('/assets/images/core/jobs/tag-icon.png');
   }
 }
+
+/* Support section styles */
+
+.support-list-element{
+    width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+    border-bottom: 1px solid silver;
+    padding: 20px;
+}
+
+.support-list-title{
+    font-weight: bold;
+    margin: 3px;
+}
+
+.support-list-content{
+    padding: 2px;
+}
+
+.support-use-case-list{
+    margin: 3px;
+    padding: 3px;
+}
+
+.support-use-case-list div{
+    font-size: small;
+    padding: 2px;
+    color: grey;
+    background-color: lightgreen;
+    display: inline-block;
+    margin: 2px;
+}


### PR DESCRIPTION
I've gone and filled out the support page of the CSS website with content. The "we're working with the department" message is still there to reflect the fact that CSS is waiting for advice from them.

It is organised into three headings: who is the page for, what problems people might have, and what services are available to students. They try to be relevant to CS students, but I aimed to get as much information on the page as possible.

On a technical note - the list of support services would be much better administered as a YAML dynamic thing like the jobs listing. I didn't trust myself to do that though, so I just wrote the content for the sake of getting it out there and available for people to use. Also, I hope I added the additional style rules in the right place? Also also, I have done nothing to the main branch, so after the merge it would still need publishing.

Keen to hear what people think! :-)