### PR TITLE
Fixed page wrapping for tiny devices

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -78,6 +78,12 @@
     line-height: 38px;
     text-transform: uppercase;
 
+    // TODO: Convert to variable media query
+    @media screen and (max-width: 450px) {
+      font-size: 35px;
+      letter-spacing: 1px;
+    }
+
     &--small {
       font-size: 16px;
       letter-spacing: 5px;

--- a/_sass/_sections.scss
+++ b/_sass/_sections.scss
@@ -30,8 +30,20 @@ body {
       margin-bottom: 30px;
       padding: 0 5px;
     }
+
+    // TODO: Convert to variable media query
+    @media screen and (max-width: 450px) {
+      // padding: 0;
+      min-width: 100%;
+    }
+
     img {
       height: 40px;
+
+     // TODO: Convert to variable media query
+     @media screen and (max-width: 450px) {
+        height: 25px;
+      }
     }
   }
 }


### PR DESCRIPTION
- The logo was making the content wider than everything else on tiny device (iPhone 5s tested), media breakpoint fixes this.
- TODO: move the 450px into a media query variable