### PR TITLE
Remove line-height from blog post img

### DIFF
--- a/_sass/_blog-posts.scss
+++ b/_sass/_blog-posts.scss
@@ -32,7 +32,6 @@ $ITEM_META_H: $ITEM_H - $ITEM_IMG_H;
       background-repeat: no-repeat;
       background-position: center;
       text-align: center;
-      line-height: $ITEM_H;
       color: black;
     }
 


### PR DESCRIPTION
Nice new events page 💯 

Current behaviour:

![image](https://user-images.githubusercontent.com/565371/52359408-217fbc80-2a3a-11e9-9350-5296d96533fc.png)

Modified behaviour:

![image](https://user-images.githubusercontent.com/565371/52359473-4116e500-2a3a-11e9-9140-2a73dfaa92a6.png)

It's not perfect, but at least readable. I don't think there's any way to centre the text vertically without introducing an additional layer in the hierarchy.
