### PR TITLE
Revert "Remove old events"

### DIFF
--- a/_events/2016-06-04_summer_bbq.md
+++ b/_events/2016-06-04_summer_bbq.md
@@ -1,0 +1,40 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: End of Term CSS BBQ
+date:     2016-06-04 12:00:00 +0100
+date_end: 2016-06-04 17:00:00 +0100
+banner: 2016-06-04_summer_bbq.jpg
+location: Brandon Hill
+fb_link: https://www.facebook.com/events/100217857059598/
+ticket_link: https://www.eventbrite.co.uk/e/css-bbq-tickets-25051709337
+price: Free
+category:
+    - Social
+cohost:
+---
+
+The annual CSS BBQ is upon us again!
+
+Join us as we continue the annual tradition marking the end of a busy year (and the end of exams!)
+
+Come for free food, drink and lots of entertainment!
+
+* **Location:** Berkeley Square, Bristol
+* **Date:** June 4, midday
+
+[Remember to book your free ticket through Eventbrite](https://www.eventbrite.co.uk/e/css-bbq-tickets-25051709337)
+
+* [Join the Facebook event](https://www.facebook.com/events/100217857059598/)
+* [Save the Google Calendar entry](https://calendar.google.com/calendar/render?eid=aWc0YnQ0dW1ncnRvOXQ0Z3QwM29idHZqdTAgY3NzYnJpc3RvbC5jby51a19jbW1iNzdpNGtkNmQ5b2tmdjVuYzFwaWJuMEBn)
+* [Got a song you want blaring at the BBQ? Add it to the jukebox](http://goo.gl/forms/1fQzdA7E68).
+
+
+## Entertainment
+
+![Entertainment poster](/assets/images/contrib/blog/2016-summer-bbq-ents.jpg)
+
+## Post event
+[View the photo album on Google Photos](https://goo.gl/photos/yLmv6sp8RroHCBbX6)

--- a/_events/2016_10_04_oracle_scale.md
+++ b/_events/2016_10_04_oracle_scale.md
@@ -1,0 +1,35 @@
+---
+layout: event
+published: truee
+cancelled: false
+cancel_reason:
+title: Oracle - Software Engineering at Global Scale
+date:     2016-10-04 13:00:00 +0100
+date_end: 2016-10-04 14:00:00 +0100
+banner: 2016_10_04_oracle_scale.png
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/1735506040033485/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Careers
+cohost:
+    - company: Oracle
+---
+
+We're lucky to have two engineers from Oracle's Bristol office coming to the department next Tuesday to talk about software deployment and delivery.
+
+In this tech talk you will learn about technologies and techniques that are used to rapidly develop, test and deploy complex software at huge scale.
+
+We'll be taking a whistle-stop tour through:
+
+* Test Driven Development
+* Continuous integration
+* Continuous delivery
+* Containerisation (Docker)
+* Logging, monitoring and metrics
+* Advanced debugging
+
+We hope to see you there!
+

--- a/_events/2016_10_13_bloomberg_jvm.md
+++ b/_events/2016_10_13_bloomberg_jvm.md
@@ -1,0 +1,39 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Bloomberg - How the JVM Executes Java
+date:     2016-10-13 13:00:00 +0100
+date_end: 2016-10-13 14:00:00 +0100
+banner: 2016_10_13_bloomberg_jvm.png
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/604257646426183/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Careers
+cohost:
+    - company: Bloomberg
+---
+
+We have an engineer from Bloomberg coming to talk to us about how the JVM executes Java.
+
+When Java was released in 1995 it was slow, a reputation it has carried for many years. Today, Java can give performance that is comparable to C++ and can emit instructions that are more optimal than code which is statically compiled. But how?
+
+This talk will take a tour from Java code and look at the journey it takes through the JVM and the optimisations in between. Using practical examples, JVM flags and the Open Source JIT Watch we will explore what the JVM in an adaptation of the classic Hello World program, you'll never look at Java in the same way again.
+
+Topics include:
+
+* Profile Guided Optimisation
+* JIT Compilation
+* Method Inlining
+* Dead Code Elimination
+* Register Allocation
+* Escape Analysis
+* Loop Unrolling
+* Monomorphic Dispatch
+* On Stack Replacement
+
+![](/assets/images/contrib/events/2016_10_13_bloomberg_jvm_poster.png)

--- a/_events/2016_10_25_bar_crawl.md
+++ b/_events/2016_10_25_bar_crawl.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS Bar Crawl
+date:     2016-10-25 20:00:00 +0100
+date_end: 2016-10-26 04:00:00 +0100
+banner: 2016_10_25_bar_crawl.png
+location: W.G. Grace
+fb_link: https://www.facebook.com/events/1864145113807249/
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/css-bar-crawl-282e/buy_ticket
+price: £5
+category:
+    - Social
+cohost:
+---
+
+The CSS Bar Crawl returns for another year!
+
+The t-shirt is just £5 includes drinks discounts and club entry.
+
+* 8pm: W.G. Grace
+* 9.30pm: Alterego
+* 11pm: Lola Lo
+
+<a class="btn btn--dark" href="https://www.bristolsu.org.uk/groups/computer-science-society/events/css-bar-crawl-282e/buy_ticket">
+  Buy the t-shirt now (£5)
+</a>
+

--- a/_events/2016_10_26_wellbeing_discussion.md
+++ b/_events/2016_10_26_wellbeing_discussion.md
@@ -1,0 +1,40 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: "CSS Discusses: Wellbeing and Workload"
+date:     2016-10-26 17:00:00 +0100
+date_end: 2016-10-26 19:00:00 +0100
+banner: 2016_10_26_wellbeing_discussion.png
+location: Pusley Lecture Theatre, Queens
+fb_link: https://www.facebook.com/events/1799726423645110
+ticket_link:
+price: Free
+category:
+    - Networking
+    - Debate
+    - Workshop
+cohost:
+---
+
+Further to the success of last year’s Panel Discussion about Equality and Diversity, the Computer Science Society will hold a cross-faculty dialogue about Wellbeing and Workload on October 26 from 5–7pm in Pugsley Lecture Theater, Queen’s Building.
+
+Members from all engineering departments are encouraged to take part in a discussion where they can learn about the topic, make suggestions to the faculty and share ideas with other staff and students.
+
+Our goals are to:
+
+* Feed back to the staff body what could be improved about wellbeing and workload
+* Provide advice for students about managing workload and stress
+* Provide information about support available inside and outside the department
+* Encourage conversation about wellbeing and break the stigma around mental health
+
+The talk will be followed by an open session for students and staff to discuss the topic further.
+
+Members of the panel discussion include:
+
+* Professor Seth Bullock, Head of Computer Science Department
+* Professor Dave Cliff, Head of Merchant Venturers' School of Engineering
+* David Bernhard, Senior Teaching Associate and member of Peace of Mind
+* Ben Marshall, Bristol Computer Science alumni and member of Peace of Mind
+

--- a/_events/2016_11_05_codelounge.md
+++ b/_events/2016_11_05_codelounge.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CodeLounge
+date:     2016-11-05 11:00:00 +0000
+date_end: 2016-11-05 17:00:00 +0000
+banner: 2016_11_05_codelounge.png
+location: MVB Lower Atrium
+fb_link: https://www.facebook.com/events/1777147739215927
+ticket_link:
+price: Free
+category:
+    - Social
+    - Networking
+    - Workshop
+cohost:
+---
+
+Confused about coding? Crying over your compiler errors? Can't cope with the computer conundrums?
+
+(Yes, we alliterate)
+
+Join us for a chance to work on a cool project, eat food and find the fun side of programming #FreeFood
+
+All CS Freshers welcome :)
+
+11am&ndash;5pm, Merchant Venturers Building Lower Atrium.
+

--- a/_events/2016_11_09_bloomberg_codecon.md
+++ b/_events/2016_11_09_bloomberg_codecon.md
@@ -1,0 +1,37 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Bloomberg CodeCon
+date:     2016-11-09 17:30:00 +0000
+date_end: 2016-11-09 20:00:00 +0000
+banner: 2016_11_09_bloomberg_codecon.png
+location: Physics Enderby
+fb_link: https://www.facebook.com/events/1665502050406417
+ticket_link: https://tinyurl.com/z9ugbym
+price: Free
+category:
+    - Careers
+    - Competition
+cohost:
+    - company: Bloomberg
+---
+
+Bloomberg CodeCon is coming to Bristol University on the 9th of November!
+
+CodeCon is a live programming contest developed in-house at Bloomberg. Push your programming and problem solving skills to the limit against the clock to win the title of Bloomberg CodeCon champion against your peers across the UK and Europe!
+
+The top winners will be invited to the Bloomberg CodeCon Global Finals in their London office in January 2017 for a chance to win an amazing prize and compete against the best students from Europe and the US!
+
+Please **make sure you register with your university email address** and bring your laptop.
+
+The event will take place at The Physics Building, Enderby Room. Come early for food and to set up as kick-off is at 6.00pm!
+
+<a class="btn btn--dark" href="https://goo.gl/maps/h3vZRLJN6XG2">
+  Location Map
+</a>
+
+Food and refreshments will be provided!
+
+We look forward to seeing you there!

--- a/_events/2016_11_16_expedia_ab_testing.md
+++ b/_events/2016_11_16_expedia_ab_testing.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Expedia - A/B and Multi-variate testing
+date:     2016-11-16 12:00:00 +0000
+date_end: 2016-11-16 13:00:00 +0000
+banner: 2016_11_16_expedia_ab_testing.png
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/667745960059783
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Careers
+cohost:
+  - company: Expedia
+---
+
+With any design, it is important to know how big a success (or failure!) a new feature is.
+
+Expedia have a proven A/B testing framework and run hundreds of experiments across all elements of their technology stack. Expedia's Experiment Engineering team provide an in-house toolkit to the rest of the organisation that enable them to implement, manage and run their tests. The results of those tests are delivered in near real-time, providing a way to quickly validate and course-correct the new features being tested.
+
+Behind all of this is a system that deals with over 70,000 experimentation requests per second, including a big data pipeline which analyses terabytes of data.
+
+Over beers and pizza, Caroline & Ralph will introduce the approach Expedia has chosen, demo their in-house tools, give an overview of the technologies in play and - perhaps most importantly - the hard lessons learned along the way.
+
+**MVB 1.06, midday, Nov 16**
+

--- a/_events/2016_11_17_games_night.md
+++ b/_events/2016_11_17_games_night.md
@@ -1,0 +1,27 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS+COGS Games and Pizza night
+date:     2016-11-17 18:30:00 +0000
+date_end: 2016-11-17 21:30:00 +0000
+banner: 2016_11_17_games_night.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/210539002717976/
+ticket_link:
+price: Free
+category:
+  - Social
+cohost:
+  - company: COGS
+---
+
+What's the best way to chill after a long day of lectures and studying? Obviously Free Pizza and Video Games!
+
+The Computer Science Society and Computer Gaming Society are teaming up to provide you with a chilled out night of Console Gaming and Food!
+
+Come down to room 1.11 for some casual gaming with your friends while nomming on Free Pizza!
+
+**MVB 1.11, 6.30pm, Nov 17**
+

--- a/_events/2016_11_22_gresham_aws.md
+++ b/_events/2016_11_22_gresham_aws.md
@@ -1,0 +1,31 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: "Gresham: AWS for secure, resilient and scalable services"
+date:     2016-11-22 13:00:00 +0000
+date_end: 2016-11-22 14:00:00 +0000
+banner: 2016_11_22_gresham_aws.png
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/802084196600375
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Careers
+cohost:
+  - company: Gresham
+---
+
+Gresham Computing are coming to the department to talk about AWS and cloud computing.
+
+We will give a brief overview of considerations and potential pitfalls when starting out building a service on a cloud computing platform. In addition to building the core functionality we will explore topics including build pipelines, continuous delivery, monitoring, high availability and disaster recovery.
+
+Discussed technologies:
+
+* Build & Deployment - AWS CloudFormation, Spot Fleets, Docker & Chef
+* Monitoring - Amazon CloudWatch, Nagios, Splunk
+* Microservices - AWS Lambda
+* Relational and Document Stores - AWS Aurora and DynamoDB
+

--- a/_events/2016_11_23_bae_ctf_talk.md
+++ b/_events/2016_11_23_bae_ctf_talk.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: BAE Systems - Binary Exploitation and Reverse Engineering
+date:     2016-11-23 11:00:00 +0000
+date_end: 2016-11-23 12:00:00 +0000
+banner: 2016_11_23_bae_ctf_talk.png
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/168887416909105
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Careers
+cohost:
+    - company: BAE Systems Applied Intelligence
+---
+
+This talk will briefly introduce BAE Systems Applied Intelligence and the [Capture The Flag event](/events/2016_12_03_bae_ctf/) which is being hosted in MVB on December 3rd. It will cover what the challenges are, how to play them and go over some of the skills and tools required to succeed in these events.
+
+In particular, we will focus on the topics of Binary Exploitation and Reverse Engineering.
+
+The goal will to be explain what these topics are, why they are of practical interest and provide a brief introduction on how to approach CTF challenges of these types, including the relevant tools that are available to help in these areas
+
+**MVB 1.06, 11am, Nov 23**
+

--- a/_events/2016_12_03_bae_ctf.md
+++ b/_events/2016_12_03_bae_ctf.md
@@ -1,0 +1,48 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: BAE Cyber Security Capture the Flag
+date:     2016-12-03 09:30:00 +0000
+date_end: 2016-12-03 16:30:00 +0000
+banner: 2016_12_03_bae_ctf.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/404245549964022
+ticket_link: mailto:ctf@baesystems.com
+price: Free
+category:
+  - Careers
+  - Competition
+cohost:
+  - company: BAE Systems Applied Intelligence
+---
+**Note: signup is essential - don't delay!**
+
+## About the challenge
+
+The Operational Cyber Group from BAE Systems Applied Intelligence are running a Capture the Flag event; a day of cyber security challenges and games. Anybody who is currently enrolled in Computer Science at Bristol can sign up and play. There are prizes for the winning team and goodies for anyone taking part!
+
+If you’re interested in a career in cyber security or just want a day of technical fun, please do sign up and take part! This is a team-based event for teams of 2 to 6 players. If you don’t have a team yet then don’t worry – register and come along anyway as teams will also be created on the day. The challenges will involve breaking into vulnerable websites, cracking ciphers, forensic analysis, reverse engineering and much more. No previous experience of these kinds of challenge is necessary; they are designed for computer science students who like taking things apart and seeing how they work.
+
+Event runs all day from 9.30 to 16:30. Lunch (Dominos!) will be provided, so get on down!
+
+## Signing up
+
+If you’re interested, please sign up by sending an email to [ctf@baesystems.com](mailto:ctf@baesystems.com) from your university email account. Please include the following information:
+
+* Your full name
+* Your year of study
+* Your course title
+* Your team name (if applicable)
+
+<a class="btn btn--dark" href="mailto:ctf@baesystems.com">
+  Sign Up Now
+</a>
+
+If you are signing up on behalf of others, please include the above information for them too. The deadline for signing up is Wednesday 30th November.
+
+Please register as soon as possible to secure your place. An email we be sent on Thursday 1st December to confirm your place and provide more details on the event and what you need to bring.
+
+**MVB 1.11, 9.30am-4.30pm, Dec 3**
+

--- a/_events/2016_12_08_oracle_ci.md
+++ b/_events/2016_12_08_oracle_ci.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+cancelled: true
+cancel_reason: Rearrange for new year
+title: "Oracle: Delivering Fast and Slow"
+date:     2016-12-08 13:00:00 +0000
+date_end: 2016-12-08 14:00:00 +0000
+banner: 2016_12_08_oracle_ci.png
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/544695072396584/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Careers
+cohost:
+  - company: Oracle
+---
+
+How do companies deliver software to their customers?
+
+How do they pick a process to build, test, and release software? A process that delivers frequent improvements whilst ensuring a reliable product? How can you assess whether the choice of steps and actions was sensible? If the choices were not sensible, how would you improve on them?
+
+We offer some answers to these questions, arming you with an understanding and some techniques to assess and improve a software delivery process.

--- a/_events/2016_12_08_pub_quiz.md
+++ b/_events/2016_12_08_pub_quiz.md
@@ -1,0 +1,35 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: 2016 Christmas Pub Quiz
+date:     2016-12-08 19:30:00 +0000
+date_end: 2016-12-08 22:00:00 +0000
+banner: 2016_12_08_pub_quiz.jpg
+location: The Brass Pig
+fb_link: https://www.facebook.com/events/1792153927726062/
+ticket_link:
+price: Free
+category:
+    - Social
+    - Competition
+cohost:
+---
+
+What's this? A CSS Pub Quiz? Christmas must have come early! (Aha, I slay myself! [Or should I say, I SLEIGH myself - Sorry, I'll stop])
+
+When the snow falls, the choir sings and the fireplace roars, who will be the ones to take home the gold?
+
+We saw an impressive victory from 2015's winners, Sack Overflow, but who will take home the £50 cash prize this year and be crowned the 2016 CSS Christmas Pub Quiz winners? (And, who will take home the £25 runners up prize?) Will it be you? Only one way to find out!
+
+There shall, of course, also be a bottle of glorious wine for the team with the best name! (So, get those creative team name thinking caps on!)
+
+Come battle out your wits, as you are quizzed on General Knowledge, Christmas, the beloved Family Feud and other mind-boggling rounds! (Banter also included, but not as a separate round)
+
+And, how much is the extravagant event, you say? £1? £10? Like, a bajillion pounds? Nope! Entry is completely FREE! £0 per team! So, why not try your luck? (You can only gain, right?)
+
+Come on down to the Brass Pig! Grab yourself a Team (Max. 5), a witty name and an inevitable victory!
+
+**The Brass Pig - 8th December - 7:30pm - Be there!**
+

--- a/_events/2017-02-27_boeing_hackathon_2017.md
+++ b/_events/2017-02-27_boeing_hackathon_2017.md
@@ -1,0 +1,55 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS Boeing Hackathon 2017
+date:     2017-02-27 13:00:00 +0000
+date_end: 2017-02-28 14:00:00 +0000
+banner: 2017-02-27-hackathon/hackathon-cover-image.png
+location: MVB
+fb_link: https://www.facebook.com/events/392877197725107/
+ticket_link: https://goo.gl/forms/lFDrMaW7tgRLT0ah2
+price: Free
+category:
+    - Tech Talk
+    - Networking
+    - Careers
+    - Competition
+cohost:
+  - company: Boeing
+---
+
+This year we're holding our first ever Explore Week Hackathon! **Make the most of a week free from lectures and deadlines** by entering our biggest, best Hackathon yet.
+
+<a href="https://goo.gl/forms/lFDrMaW7tgRLT0ah2" class="btn btn--dark">Sign Up Now</a>
+<a href="/hackathon-2017" class="btn btn--dark">Find out more</a>
+
+## [Sign up now!](https://goo.gl/forms/lFDrMaW7tgRLT0ah2)
+
+Teams can be composed of **up to 6 people**. Make sure you [sign up](https://goo.gl/forms/lFDrMaW7tgRLT0ah2) so we can reserve your place!
+
+**Don't have a team yet?** We're happy to help match you up with people! Just mention it on the signup form.
+
+Never done something like this before? Don't worry - anyone can participate!
+
+## Prizes
+
+There are three prize categories:
+
+### Best environmental impact
+£100 cash per team member
+
+### Best-implemented prototype
+Quadcopter per team member
+
+### Most creative idea
+Google Chromecast per team member
+
+## Theme
+
+This year's theme: **build something that might help protect or improve the environment**!
+
+We're deliberately keeping this as broad as possible, because we want to see what you come up with!
+
+**MVB Atrium - 27th February 2017 - midday**

--- a/_events/2017-06-02_bbq.md
+++ b/_events/2017-06-02_bbq.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: 2017 BBQ
+date:     2017-06-02 12:00:00 +0100
+date_end: 2017-06-02 16:00:00 +0100
+banner: 2017-06-02-CSS-BBQ-2017/BBQ-wide.png
+location: Brandon Hill
+fb_link:
+ticket_link: https://www.eventbrite.co.uk/e/css-bbq-2017-tickets-2546474574
+price: Free
+category:
+    - Social
+cohost:
+---
+
+**The Old Bowling Green, Brandon Hill - 2nd June 2017 - 12-6pm**
+It's that time of year again! Celebrate the end of exams with our annual CSS BBQ! Join us at The Old Bowling Green on Brandon Hill for a day of free food, drinks and entertainment!
+
+[Remember to book your free ticket through Eventbrite](https://www.eventbrite.co.uk/e/css-bbq-2017-tickets-2546474574)
+
+![](/assets/images/contrib/events/2017-06-02-CSS-BBQ-2017/BBQ.jpg)
+
+![](/assets/images/contrib/events/2017-06-02-CSS-BBQ-2017/bbq-location.png)
+
+![](/assets/images/contrib/events/2017-06-02-CSS-BBQ-2017/css-bbq-poster.png)

--- a/_events/2017-10-17_barcrawl.md
+++ b/_events/2017-10-17_barcrawl.md
@@ -1,0 +1,57 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS Bar Crawl 2017
+date:     2017-10-17 19:30:00 +0100
+date_end: 2017-10-18 04:00:00 +0100
+banner: 2017-10-17_barcrawl.jpg
+location: Lola Lo's
+fb_link: https://www.facebook.com/events/491272451246870
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/css-bar-crawl-2017/buy_ticket
+price: 6.50
+category:
+    - Social
+cohost:
+---
+
+It's that time of year again! Get your t-shirt and join us on the 2017 CSS Bar Crawl.
+
+<a class="btn btn--dark" href="https://www.bristolsu.org.uk/groups/computer-science-society/events/css-bar-crawl-2017/buy_ticket">
+  Get your t-shirt now 👕🎽👚👔 (£6.50)
+</a>
+
+For £6.50 you get:
+* An **incredibly exclusive** bar crawl t-shirt
+* **Free entry** and **queue jump** to Lola Lo until 10.30pm
+* £2.50 singles at Brass Pig / 5 bombs for £10 / 6 flavoured house shots for £10
+* more to come
+
+* **7.30pm** The Berkeley
+* **8.30pm** The Brass Pig
+* **9.30pm** mbargo
+* **10.30pm** Lola Lo
+
+## 👪 FAMILIES 👨‍👨‍👦
+
+You are encouraged to invite your CSS children for dinner before the bar crawl. We'll supply one £5 Sainsbury's voucher per family. We'll be in touch closer to the time.
+
+Stuck for ideas? [Here are some super-cheap meal suggestions](https://docs.google.com/document/d/1EmM2h5kJbFCklKnKz7HgAVVMYRnUVHOm1Q1JBwdXu8k/edit)
+
+<a class="btn btn--dark" href="https://www.bristolsu.org.uk/groups/computer-science-society/events/css-bar-crawl-2017/buy_ticket">
+  Buy the t-shirt now (£6.50)
+</a>
+
+<a class="btn btn--dark" href="https://www.facebook.com/events/491272451246870">
+  Facebook event
+</a>
+
+<a class="btn btn--dark" href="https://calendar.google.com/calendar/b/1/render#eventpage_6%7Ceid-MGw5bTVvMDVxMjdobWV2NGxwZmowNDM4dmUgY3NzYnJpc3RvbC5jby51a19jbW1iNzdpNGtkNmQ5b2tmdjVuYzFwaWJuMEBn-1-0-">
+  View on Google Calendar
+</a>
+
+![Bar Crawl t-shirt](/assets/images/contrib/events/2017-09-29-css-bar-crawl/bar-crawl-tshirt-preview.png)
+
+![Bar Crawl 2016](/assets/images/contrib/events/2017-09-29-css-bar-crawl/bar-crawl-photo-1.jpg)
+![Bar Crawl 2016](/assets/images/contrib/events/2017-09-29-css-bar-crawl/bar-crawl-photo-2.jpg)

--- a/_events/2017_01_30_post_exam_social.md
+++ b/_events/2017_01_30_post_exam_social.md
@@ -1,0 +1,26 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: End Of Exams Social
+date:     2017-01-30 20:00:00 +0000
+date_end: 2017-01-31 04:00:00 +0000
+banner: 2017_01_30_post_exam_social.jpg
+location: The Berkeley
+fb_link: https://www.facebook.com/events/1657929487834605/
+ticket_link:
+price: £4
+category:
+    - Social
+cohost:
+---
+
+Time to celebrate the end of Exams!
+
+Meet at the Berkeley at 8pm.
+We'll be heading to Analog (Bunker) at around 11pm to top off the night.
+
+ANALOG TICKETS ON SALE:
+£4 at 12-1 pm, Friday and Monday in MVB.
+

--- a/_events/2017_01_31_oracle_ci.md
+++ b/_events/2017_01_31_oracle_ci.md
@@ -1,0 +1,34 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: "Oracle: Delivering Fast and Slow"
+date:     2017-01-31 12:00:00 +0000
+date_end: 2017-01-31 13:00:00 +0000
+banner: 2017_01_31_oracle_ci.png
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/544695072396584/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Networking
+  - Careers
+cohost:
+  - company: Oracle
+---
+
+How do companies deliver software to their customers? Oracle has to do this at huge scale, delivering software at a wide variety of frequencies for a whole range of different needs.
+
+Topic we'll cover include:
+
+* Continuous Delivery
+* Continuous Integration
+* Clojure
+* Docker
+
+How do you pick a process to build, test, and release software? A process that delivers frequent improvements whilst ensuring a reliable product? How can you assess whether the choice of steps and actions was sensible? If the choices were not sensible, how would you improve on them?
+
+We offer some answers to these questions, arming you with an understanding and some techniques to assess and improve a software delivery process.
+

--- a/_events/2017_02_08_deloitte_security.md
+++ b/_events/2017_02_08_deloitte_security.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Deloitte - Security in Banking
+date:     2017-02-08 13:00:00 +0000
+date_end: 2017-02-08 14:00:00 +0000
+banner: 2017_02_08_deloitte_security.png
+location: Pugsley Lecture Theatre
+fb_link: https://www.facebook.com/events/1866119526989648
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Careers
+cohost:
+  - company: Deloitte
+  - Kiril Kamburov (Security Engineer, Manager)
+  - Trevor Bolden (Penetration Testing, Senior Manager)
+---
+
+How do you deliver a secure Mobile Banking Experience? Our sponsor, Deloitte, are experienced consultants to the banking industry and, in this talk, they'll reveal some of the tricks of the trade.
+
+The talk will focus on applying Security Engineering when delivering Mobile Banking Platforms - the critical activities, some of the technical issues and the importance of "secure by design". As part of the talk, Trevor and Kiril will also discuss some of the other aspects of security in the financial sector, e.g. offensive security under schemes such as CBEST.

--- a/_events/2017_02_23_hashcode.md
+++ b/_events/2017_02_23_hashcode.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Google Hash Code 2017
+date:     2017-02-23 17:00:00 +0000
+date_end: 2017-02-23 22:00:00 +0000
+banner: 2017_02_23_hashcode.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/1852770648332217
+ticket_link: https://hashcode.withgoogle.com/signup.html
+price: Free
+category:
+    - Careers
+    - Competition
+cohost:
+    - company: Google
+---
+
+Hash Code is an online team programming competition created by Google. The goal is to compete in teams, solving algorithmic challenges inspired by the kind of problems faced at Google.
+
+The first round is an online competition form 5:30pm to 10:30pm on Thursday 23rd Feburary. We will be hosting a room for your team to compete, we will providing free food and drink to fuel you whilst you compete.

--- a/_events/2017_03_02_games.md
+++ b/_events/2017_03_02_games.md
@@ -1,0 +1,22 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS + COGS Pizza/Games Night
+date:     2017-03-02 17:00:00 +0000
+date_end: 2017-03-02 20:00:00 +0000
+banner: 2017_03_02_games.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/1835664206693165/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+    - company: COGS
+---
+
+CSS and COGS meet again for another epic evening of Pizza-fuelled gaming.
+
+With no lectures in Explore Week and free Pizza and drinks throughout the evening, there is no excuse not to come!

--- a/_events/2017_03_02_lightning_talks.md
+++ b/_events/2017_03_02_lightning_talks.md
@@ -1,0 +1,35 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Lightning Talks
+date:     2017-03-02 14:30:00 +0000
+date_end: 2017-03-02 16:00:00 +0000
+banner: 2017_03_02_lightning_talks.png
+location: MVB Lower Atrium
+fb_link: https://www.facebook.com/events/366437693738236
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - Matt Pickering
+    - Alessio Zakaria
+    - obert Bragg
+    - Jamie Willis
+    - Elliot Potts
+---
+
+You've seen talks put on by companies in the industry - Now get ready for talks given by our very own students!
+
+We have the following students lined up to give lightning talks on the following topics:
+
+Schedule (Provisional):
+- 2.30 - Matt Pickering: Why we care about Programming Language Research
+- 2.50 - Alessio Zakaria: Rust: A case study in safety
+- 3:10 - Robert Bragg: Medieval Weaponry in Video Games
+- 3.30 - Jamie Willis: Exploring Compositional Inheritance
+- 3.50 - Elliot Potts: Interactive Programming with Idris
+
+We hope to see you there!

--- a/_events/2017_03_03_all_stars.md
+++ b/_events/2017_03_03_all_stars.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Student/Staff All-Stars Trip
+date:     2017-03-03 17:00:00 +0000
+date_end: 2017-03-03 21:00:00 +0000
+banner: 2017_03_03_all_stars.png
+location: Allstars Sports Bar Bristol
+fb_link: https://www.facebook.com/events/198441143969693/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Why not round off Explore Week with a well deserved game of pool and a drink down at the All-Stars Sports Bar, with your peers?
+
+We have booked out a big room of pool tables for a Sports Bar CSS trip. This event is for both Students and Staff so we'd love to see you down there mingling with those within the department!
+
+What other way is there to spend a Friday evening?

--- a/_events/2017_03_22_fun.md
+++ b/_events/2017_03_22_fun.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Really fun things you aren't supposed to do with a CS degree
+date:     2017-03-22 12:00:00 +0000
+date_end: 2017-03-22 13:00:00 +0000
+banner: 2017_03_22_fun.jpg
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/959695247494276/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - Eric R. Johnston
+---
+
+Spring 1990, Berkeley: "You're really going to need to narrow your focus if you expect to graduate. And if you want a job afterward. I hope you've decided what's important to you."
+"Yes I have."
+"Oh good. And that is what?"
+"Surprise and whimsy."
+
+Eric R. Johnston ("EJ") did graduate, and used skills from his EE/CS degree to do a ridiculously wide variety of projects.
+
+To date they've included robotics at NASA, special effects and video games at Lucasfilm, wrist-mounted superhero gadgets for Make-A-Wish, neuroscience, odd mechanical devices, astronomy, and for the past year he's been working on quantum engineering research here at the University of Bristol.
+
+His past projects have earned five patents, two technical Oscars, a cover of Nature, San Francisco's Key to the City, and a personal blessing from the Dalai Lama. He's found a specific and reasonably consistent way to use a CS degree to work on anything you want to, and is looking forward to sharing it.
+

--- a/_events/2017_03_23_dug.md
+++ b/_events/2017_03_23_dug.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Programming 14 Petaflops of Xeon Phis
+date:     2017-03-23 14:00:00 +0000
+date_end: 2017-03-23 15:00:00 +0000
+banner: 2017_03_23_dug.jpg
+location: MVB 1.06
+fb_link: https://www.facebook.com/events/1024611060971988/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: DownUnder GeoSolutions
+---
+
+DownUnder GeoSolutions are giving a talk about how they use thousands of Intel Xeon Phi processor instead of GPU's in their high performance computing setup.
+
+Although general-purpose GPUs have all of the mindshare, we've deployed thousands of the Intel Xeon Phi processors, putting us in stark contrast to most of the commercial HPC world.
+
+If you've never heard of them, you're not alone. Xeon Phi is the product name for Intel's "Many Integrated Core" architecture, which combines 60+ x86 cores, AVX-512 vector instructions, and high-performance memory into a single package.
+
+This talk discusses:
+- Why we chose the Phi, when almost everyone else chose GPUs
+- How and why we build the clusters that we do, including a novel solution to the cooling challenge of putting 5 teraflops in each 1 RU
+- Programming techniques that resulted in better performance than Intel's own engineers thought possible, and
+- A look at our new 14 petaflop machine, based on the next generation of Phi

--- a/_events/2017_03_30_karaoke.md
+++ b/_events/2017_03_30_karaoke.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Karaoke Social
+date:     2017-03-30 20:00:00 +0000
+date_end: 2017-03-30 23:59:00 +0000
+banner: 2017_03_30_karaoke.jpg
+location: Illusions Magic Bar
+fb_link: https://www.facebook.com/events/1417035888318270/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+After the Monty Widenius talk (https://www.facebook.com/events/416323622051323/), we shall be heading to the pub. Then, at 8pm, we shall be heading to Illusions Magic Bar for some good old Karaoke!
+
+Come and meet up with your CSS chums one last time before the Easter holidays in the best way possible - Over some drinks while embarrassing yourselves on stage!
+
+Because nothing says fun like catchy tunes, alcoholic beverages and sore throats the morning afterwards!

--- a/_events/2017_03_30_mysql.md
+++ b/_events/2017_03_30_mysql.md
@@ -1,0 +1,22 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: MySQL Talk
+date:     2017-03-30 17:00:00 +0000
+date_end: 2017-03-30 18:00:00 +0000
+banner: 2017_03_30_mysql.png
+location: Pugsley Lecture Theatre, Queen's Building
+fb_link: https://www.facebook.com/events/416323622051323
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - Monty Widenius - creator of MySQL
+---
+
+We're hosting a talk by Monty Widenius, author of the MySQL database. MySQL was sold to Sun Microsystems in 2008.
+
+Widenius is now the CTO of MariaDB, which provides commercial support for the community-developed MariaDB fork of MySQL.

--- a/_events/2017_04_26_agm.md
+++ b/_events/2017_04_26_agm.md
@@ -1,0 +1,203 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: AGM 2017
+date:     2017-04-26 17:00:00 +0100
+date_end: 2017-04-26 20:00:00 +0100
+banner: 2017_04_26_agm.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/1936619736573029/
+ticket_link:
+price: Free
+category:
+    - Social
+    - Networking
+cohost:
+---
+
+The time of year has come! The time where the CSS Committee step down and pass the torch onto a new team to carry the future CSS banner into battle and lead the greatest society on Earth!
+
+We shall be supplying Pizza, Beer and Democracy! (the big three). All you need to bring is your voice!
+
+The Annual CSS AGM is the event where we gather together as a society and discuss how the year has gone and vote on how we continue forward (as well as voting in a brand new committee!)
+
+## President
+
+The head of the committee and the person mainly responsible for the committee. The President leads the society. The President also organises committee meetings, chairs all meetings and makes the agendas. The President is also generally responsible for delegating responsibilities and making sure people are on top of their jobs. Generally, if outsiders want to interact with the society, the President will be their first point of contact.
+
+### Alessio Zakaria
+> As a member of this years committee I believe that we have provided a great year of events and opportunities. I will continue the packed year we've had, as well as tailor events more to the student body by holding more larger hack-style events like the Hackathon and Google Hash Code. Tutorials and introduction type events would be held to ensure that all who want to take part have the confidence to do so. These events could be held in conjunction with other engineering department societies to create a wider community as well as expand everyone's skill-sets.
+
+> I also want to increase the role that the society plays in academic and pastoral care by providing dedicated pathways for members of the society to escalate issues to do with workload, quality of work and any other academic or pastoral issue. The society must be better equipped to deal with, and be more involved with the academic side of university life. This could potentially be in the form of collating revision notes for modules or arranging study groups.
+
+### Kyle Welch
+> I think Computer Scientists at Bristol form an amazing community of people and I want to make sure the community is given every opportunity to thrive. I want the society to be one where everyone feels like they can openly contribute and have an impact on what the society does. As President my key policies would be to introduce a spring formal, organise more regular socials, and provide members with more opportunities to take part in events that enrich their academic interests (Hackathons, Coding Challenges, etc.). If you’d like to know more about my policies, check out my manifesto.
+
+## Vice-president
+
+Second in command. The Vice-president assists the president in matters and is generally responsible for sponsorship (Getting sponsorships, getting contracts, being the point of contact for sponsors, etc.). The Vice-president can also act as a secondary chair for meetings (Or the primary chair if the President can’t make it but wants the meeting to go ahead).
+
+### Ross Gardiner
+> It's been great fun to be webmaster this year. Among other things, I:
+
+> - Relaunched the society website and job board
+> - Designed a whole load of posters and merchandise
+> - Helped run over 20 events
+
+> This year, I want to:
+
+> - Run joint events, especially with BEEES and Women in Engineering.
+> - Communicate better with sponsors, giving us more freedom to do what *you* want.
+> - Make the new MVB hackspace a hub for informal, interdisciplinary learning.
+> - Fix the SSLC - CS students don't know how to bring issues to the attention of the department.
+
+## Secretary
+
+Responsible for taking down minutes of every meeting and AGM/EGM, as well as making the minutes available. The secretary is also responsible for making sure the document side of things are functioning well (Health and safety forms, Freshers Fair stall form, any other SU documents, etc.).
+
+### Thomas Walker
+> Everyone has that friend who deals with the paperwork for group trips; I’m always that person, so if you vote for me you know that the role of Secretary is in safe hands.
+
+> With all the other candidates promising bigger and better events, an efficient and organised administrative side of the CSS is more important than ever to ensure that next year is the greatest year for the CSS so far. I’ve worked as a part of a committee before as Head Boy of my school, which has given me the skills and experience needed for this role. I've also gained experience dealing with important forms and documents when I worked at an accountants.
+
+> Many of you may believe that the document side of things are boring, however I understand just how essential the role of Secretary is to guaranteeing the efficient running of the CSS and would love the chance to fill that role this year.
+
+### Eleanor Cox
+> The secretary position is essential for keeping CSS running smoothly, but is often kept behind the scenes. I want to encourage transparency by publishing minutes for all to see so society members know what’s going on and can actively support or oppose changes being made. I’m experienced with administration, having run a first aid course, an afterschool club, sales events for a Young Enterprise company and large group trips, all of which required extensive documentation. But most importantly, I’m here to ensure documents are filled in before you even know you need them!
+
+> Above the role of secretary, I aim to be a proactive committee member who will work for your best interests. I’d like to foster a greater sense of community, ensuring everyone knows who the committee members are and where they can go to get the help they need, be it with running an event or applying to internships. And finally, whilst mental health is a buzzword around the University, I believe it is massively important to ensure the wellbeing of every individual in our department and that it is the duty of the society to do as such. CSS will be there for you, and will work together with the SSLC and the SU to give you a more balanced university life.
+
+## Treasurer
+
+Responsible for controlling our money. The Treasurer is CSS’ contact with our bank and is responsible for any matter involving money. They are also responsible for setting up bank access for themselves and the President. The Treasurer should provide a ‘Treasurer’s update’ (Just a quick update about how much money is in the account) at committee meetings about every month or so.
+
+### John Griffith
+> Last year as events Organiser I was in charge of running all our events throughout the year. I successfully helped organise a wide variety of tech talks, coding competitions and our annual Hackathon.
+
+> This year I want to be in charge of ensuring that we have the money available to run all our events. Pizza is expensive!
+
+> I aim to do this by
+> - Strengthening existing ties with our sponsors
+> - Seeking out new links with exciting tech companies (We have a lot of less well known startups in Bristol!)
+> - Look to collaborate more with BEEES and Women In Engineering
+> - Being good with numbers, making sure everything adds up!
+
+### Elias Kassell Raymond
+> Last year I worked for several not-for-profit organisations, and would love to use the skills I acquired to provide fresh and innovative methods for managing the society’s money.
+
+> As treasurer, I will focus on several key aspects of our organisation.
+
+> Being as open as possible about our assets and their availability to members of the society. For example, I will look to expand on our collection of Arduinos/Raspberry Pis, sensors and motors for the next Hackathon!
+
+> Investment in the future. A stronger society will lead to an increased number of sponsors, and will increase the amount of money they are willing to splurge on us (meaning more free pizza!).
+
+> Collaborating with other societies. As the main society for the best course in Bristol, we should show off our talents to as many other societies as possible.
+
+> Believe in CSS!
+
+## Events Lead (fka Events Rep)
+
+Part of the Events team. The Events Lead leads the Events team, is mainly responsible for any events that the society holds (Besides socials) and works with the Outreach Officer and Equality and Diversity Officer to organise events (Such as Hackathons, Tech Talks, Workshops, etc.)
+
+### Vansh Dassani
+> I've had some experience running tech-based events at a startup accelerator, and believe that I can bring a lot to the committee. I'd like to increase the amount of outreach the committee does with regards to events, because I've often not heard about various events until after they've happened. I'm keen to get fellow students more involved with the tech community within Bristol, as it's a great way for us to gain and improve skills, and make connections that could help us in the future. Some of the events I would like put on include Start-up showcases, Elevator pitch competitions and networking events with professionals in the Bristol area.
+
+### Samat Alpyssov
+> My name is Samat Alpyssov and I am applying to be Events Lead, because:
+> 1. I love Computer Science Society and I would be very happy and passionate about helping CSS to organise great and memorable events.
+> 2. I was responsible for organising lots of different events in my high school, including “Graduation official party” and “Graduation day”.
+> 3. I developed adaptability, flexibility and cultural awareness during studying in different countries with students from all over the World. These will help me to hear the voices of all the members of the CSS committee and conduct a variety of completely different activities, at the same time interesting for all members.
+> 4. I developed team working skills during working in CELFS team on IFP (International Foundation Program) in the University of Bristol, where I helped with organising Online Open days for prospective students.
+> 5. I was elected to be a Course Rep for the next academic year (2017-2018). I am sure, this position will help me and the whole CSS committee to achieve higher heights, then ever before.
+
+## Outreach Officer
+
+Is a part of the Events team. The Outreach Officer is mainly responsible for events that relate to the society’s Outreach side of things and is the main point of contact for Outreach affairs. The Outreach Officer is also responsible for working with the Events Lead and Equality and Diversity Officer to organise events (Even events not relating to Outreach)
+
+### Palvi Shah
+> The Outreach officer's main role is to work with outside organisations such as schools to increase exposure to Computer Science. When I was doing my A-Levels, I would have benefited from someone introducing me to the
+possibilities of this field. As Outreach Officer, I really want to inspire new people to get into Computer Science who wouldn't have originally considered it as a path for them.
+
+> As a part of the Events Team, I would like to get more people involved in future CSS events and bring together people from the CSS society and the wider community by organising new outreach events. For example, a mentoring scheme.
+
+## Equality and Diversity Officer
+
+Is a part of the Events team. The Equality and Diversity Officer is mainly responsible for events that relate to the society’s Equality and Diversity side of things and is the main point of contact for Equality and Diversity affairs. The Equality and Diversity Officer is also responsible for working with the Events Lead and Outreach Officer to organise events (Even events not relating to Equality and Diversity)
+
+
+### Iwan Pettifer-Cole
+> Equal representation for all students in the department, regardless of gender, race, sexual orientation, disability and background is something I will deliver as your Equality and Diversity officer.
+
+> I am committed to ensuring the department and society are free from any and all forms of discrimination. I will ensure that those who have been subject to any discrimination have an approachable and confidential channel on which to report the incidents.
+
+> From my experience in the LGBT+ Society, I will promote diversity in all CSS events and socials, as everyone should feel welcomed and be able to enjoy all the opportunities the society has to offer.
+
+> Being in university is challenging, and I believe that achieving true equality plays a key role in mental well-being.
+
+> 🌈 In the wise words of RuPaul, "If you can't love yourself, how in the hell you gonna love somebody else?" 🌈
+
+## Webmaster
+
+Responsible for maintaining our website. This involves ensuring the website is up and running, reviewing submitted pulls on Github, reviewing submitted jobs to our jobs board, etc. The Webmaster is also responsible for making sure the society has the tech it needs to run (For example, making sure we have the correct HDMI conversion cables that speakers can use for their Tech talks)
+
+### Louis Heath
+> Vote for me to be Webmaster if you value the CSS website and want it to be in reliable hands. I promise that every event and job post will be up swiftly and smoothly, and that all tech talks rooms have a plentiful supply of cables, adapters and extensions.
+
+> Some skills I can bring to the table:
+> * I work as a Deliveroo courier - I am committed to providing the best service possible at all times, and I manage my time efficiently.
+> * I used to work at Waitrose - responsible for ensuring that no customers fall ill from out of date food, I learned to be reliable and consistent in my efforts.
+> * I volunteered teaching children to swim - caring for and guiding children as young as six takes patience and strong communication skills as well as a high level of trust between me and both my pupils and my peers.
+> * I enjoy being in a team - I have a long history playing rugby and I am part of the University's Boat (Rowing) Club; both of which require the ability to cooperate - essential for being part of a committee.
+
+## Sports And Social Officer (fka Sports Rep)
+
+Responsible for managing/organising our sports teams and society socials. The Sports And Social officer should set up teams for sports where there is sufficient demand within the society for it and should also set them up within the SU league, if desired. The Sports And Social Officer is also responsible for organising society socials, contacting the location to book the social and getting any discounts (if possible)
+
+### Katie Marquand
+> "You can retake an exam but you can't relive the sesh" - These are the wise words I want the Computer Science Society to live by. If I am elected I would like to introduce more frequent, bigger and better socials than ever before. These will be everything from pub golf, scavenger hunts and club nights, to paintball or board game nights, but I will make sure there is something that everyone can get involved in. My aim is to create an even bigger sense of community within the society and make sure that everyone has a good experience.
+
+> I would also like to introduce an End of Year Ball as an opportunity to celebrate everything throughout the year and have another chance to drink and be merry.
+
+> On the sport side of things, I'm an avid hockey player and have already been involved in the SU league this year so I am familiar with how things are run. I am keen to get teams together if the demand is there for a more relaxed opportunity to play.
+
+> If you vote for me, all of your wildest dreams will come true.
+
+## Advertising Officer (fka Press Officer)
+
+Responsible for the society’s advertisement and designs. The Advertising officer should design a poster for every event the society holds (Tech Talks, Hackathons, Socials, etc.) and is responsible for making the designs for merchandise such as Hoodies and Bar Crawl shirts.
+
+### Abdu Elturki
+> I have enjoyed being Advertising Officer for the 2016-2017 Committee, and I believe I could do even better job for the next year. I have made most of this year posters for the society, and in my opinion it has attracted a lot of attention, where I have worked many hours on them to make sure they look appealing. As Advertising Officer, I will make sure that our members won't get any spammy emails and make sure to provide members the information that they want for every events, tech talks, and socials.
+
+---
+
+## Motions
+
+### Motion 2017-01: Addition of 2 'General' committee roles
+
+This motion will add 2 CSS committee roles, both named 'General'. These two roles will be full roles of the committee, have full voting rights (and will attend meetings) but will not have a specific responsibility. The 'general' role will be more of an assisting role to any other role that needs an extra pair of hands. For example, if the Treasurer needs to get forms filled and submitted to the bank but cannot do it, for some reason, or the Advertising officer needs posters put up but is away for a few days, the 'General' role can be asked to do either of these tasks.
+
+### Motion 2017-02: Introduce a first year CSS Rep
+
+Currently, first years don't have anyone to represent them on the CSS committee due to all positions being elected in the AGM during the previous year.
+
+This motion proposes the CSS introduce a First Year CSS Rep to the committee. The position would be elected in an EGM in October or November. An interim rep would be elected at the AGM to hold the position until the EGM in October or November.
+
+A First Year CSS Rep would be responsible for providing first year's with a voice in the committee. They would also play a major part in organising first year specific events and schemes (like parenting) for the following year.
+
+A First Year CSS Rep can only be nominated if they are currently studying their first year of Computer Science.
+
+---
+
+If you would like to run for a 2017/18 committee position or submit a motion, please [fill out the form](https://goo.gl/forms/sF1PL3w7bkVqmE7Z2).
+
+[CSS Constitution](/constitution)
+
+* The deadline for applying for a committee position is **Sunday 23rd April 11:59pm**
+* The deadline for submitting a motion is **Tuesday 25th April 11:59pm**
+
+If you are running for a position or submitting a motion, good luck!
+We hope to see you all at the AGM!
+

--- a/_events/2017_04_27_arm_formal_verification.md
+++ b/_events/2017_04_27_arm_formal_verification.md
@@ -1,0 +1,26 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Formal Verification - ARM
+date:     2017-04-27 14:00:00 +0100
+date_end: 2017-04-27 15:00:00 +0100
+banner: 2017_04_27_arm_formal_verification.jpg
+location: Queens 1.18
+fb_link: https://www.facebook.com/events/144316992767733/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Networking
+  - Careers
+cohost:
+  - company: arm
+  - Will Keen, Senior Engineer, ARM
+---
+
+In the ever-accelerating industry of CPU design, Formal Verification is becoming an essential methodology in ensuring that correct designs are shipped to customers. In this talk, we will explore the nature of Formal Methods as applied to digital electronics. We will look at how the technology works, its history, its strengths and weaknesses in comparison with traditional simulation-based methods, and its application on real CPU designs. We will see why electronics companies are so excited about it, and the growing requirement for good tools and engineers in today’s marketplace.
+
+The presenter is an engineer who has witnessed first-hand the growth of Formal Methods at a major CPU design company over several years, and created new techniques in applying formal methods. There will be time for in-depth Q&A.
+

--- a/_events/2017_09_18_welcome_drinks.md
+++ b/_events/2017_09_18_welcome_drinks.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Welcome Drinks 2017
+date:     2017-09-18 19:30:00 +0100
+date_end: 2017-09-19 01:00:00 +0100
+banner: 2017_09_18_welcome_drinks.jpg
+location: The Berkeley
+fb_link: https://www.facebook.com/events/275610189604165/
+ticket_link:
+price: Free
+category:
+    - Social
+    - Networking
+cohost:
+---
+
+Welcome, CSS members old and new! Come join us at The Berkeley for a few pints (and maybe some onion rings...)
+
+In your first year? Don't be shy - come and say hi!
+

--- a/_events/2017_10_13_bloomberg_codecon.md
+++ b/_events/2017_10_13_bloomberg_codecon.md
@@ -1,0 +1,39 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Bloomberg CodeCon Qualifiers
+date:     2017-10-13 18:30:00 +0100
+date_end: 2017-10-13 21:30:00 +0100
+banner: 2017_10_13_bloomberg_codecon.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/1771833383117588/
+ticket_link: https://tinyurl.com/yamoka5k
+price: Free
+category:
+    - Networking
+    - Competition
+cohost:
+    - company: Bloomberg
+---
+
+CodeCon is coming back to Bristol on the 13th October! CodeCon is a live programming contest developed in-house at Bloomberg.
+
+Push your programming and problem solving skills to the limit against the clock to win the title of Bloomberg CodeCon champion against your peers across the UK and Europe!
+
+Our top winners will be invited to the Global Finals in Bloomberg's London office in January 2018 for a chance to win an amazing prize and compete against the best students from Europe and the US!
+
+Please make sure you register with your university email address and bring your laptop.
+
+The event will take place in MVB 1.11 on the 13th October 2017.
+
+Kick-off at 6.30pm, come early to get a seat! Food and refreshments will be provided.
+
+<a class="btn btn--dark" href="http://tinyurl.com/yamoka5k">
+  Sign up here!
+</a>
+
+We look forward to seeing you there!
+
+CSS and the Bloomberg CodeCon Team ❤️

--- a/_events/2017_10_19_creditcall.md
+++ b/_events/2017_10_19_creditcall.md
@@ -1,0 +1,42 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Eat; drink; talk code - with Creditcall
+date:     2017-10-19 17:00:00 +0100
+date_end: 2017-10-19 22:00:00 +0100
+banner: 2017_10_19_creditcall.png
+location: The White Harte
+fb_link: https://www.facebook.com/events/1918754915115321
+ticket_link: https://go.creditcall.com/students
+price: Free
+category:
+    - Social
+    - Networking
+    - Careers
+cohost:
+    - Creditcall
+---
+
+[Creditcall](http://www.creditcall.com/) is hosting a social at the White Harte immediately after the careers fair on October 19! Come along for a chat and free food.
+
+Here’s your chance to mingle with like-minded students and experienced developers alike to share ideas and insights on all things code in central Bristol over a few drinks and some grub.
+
+
+<a class="btn btn--dark" href="http://go.creditcall.com/students">
+  GET A TICKET NOW! 🍻
+</a>
+
+-----------
+
+Who is Creditcall?
+
+Developers worldwide use our SDKs in their own solutions to enable them to accept payments. We connect mobiles, websites, stores, parking and train station ticketing machines with a bank to process debit or credit card payments quickly, reliably, & securely.
+
+-----------
+
+Being born and bred in Bristol (though we’re now known worldwide), all of us at Creditcall HQ wanted to welcome new and returning students to Bristol - so we asked everyone in our Bristol office to share their best bits of Bristol:
+
+[Creditcall: 10 things you should know when studying in bristol](https://www.creditcall.com/10-things-you-should-know-when-studying-in-bristol)
+

--- a/_events/2017_10_24_g-research_coding.md
+++ b/_events/2017_10_24_g-research_coding.md
@@ -1,0 +1,34 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: G-Research Coding Challenge
+date:     2017-10-24 18:30:00 +0100
+date_end: 2017-10-24 21:30:00 +0100
+banner: 2017_10_24_g-research_coding.png
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/1619186934779420/
+ticket_link: mailto:graduates@gresearch.co.uk
+price: Free
+category:
+    - Careers
+    - Competition
+cohost:
+    - G-research
+---
+
+Come along to 1.11A MVB on the 24th October for coding, prizes and food - and a chance to chat with one of our great sponsors [G-Research](http://www.g-research.co.uk/)!
+
+-----------
+
+G-Research is a leading quantitative research and technology company. We apply scientific techniques to find patterns in large, noisy and real-world data sets, using the latest statistical and "big data" analysis methodologies to predict global financial markets.
+
+Please join us for our annual coding challenge where you will compete in teams in a series of progressively more difficult sentiment analysis challenges. This is a great chance to test your problem solving and coding skills and a chance to win a £50 Amazon vouchers per team member (plus prizes for runners up!)
+
+To take part all you need is at least one laptop per team and have a development environment set up for C#, Java or Python and you must be able to provide your own internet access.
+
+Afterwards we will provide food and drinks and a chance for you to talk to our employees informally about internships, graduate roles and life at G-Research!
+
+To register your interest please email [graduates@gresearch.co.uk](mailto:graduates@gresearch.co.uk). You can register alone or as part of a team of up to 4 members, if you register individually you will be allocated a team at the event.
+

--- a/_events/2017_11_01_ux.md
+++ b/_events/2017_11_01_ux.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Bloomberg UX design and accessibility
+date:     2017-11-01 12:00:00 +0000
+date_end: 2017-11-01 13:00:00 +0000
+banner: 2017_11_01_ux.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/173556283225039
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Careers
+cohost:
+    - company: Bloomberg
+---
+
+We have an exciting talk this week from Bloomberg about UX.
+
+12-1PM, Wednesday 1st November, 1.11A
+
+Brendan Nelson, a UX designer at Bloomberg, will look at how UX works at Bloomberg, and explore the importance of accessibility in creating truly user-centred applications.
+
+We'll also be talking about our first Hack in explore week of this term!
+
+Free food and drink as always
+

--- a/_events/2017_11_06_alexa.md
+++ b/_events/2017_11_06_alexa.md
@@ -1,0 +1,32 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Amazon Alexa // Whos round is it anyway?
+date:     2017-11-06 13:00:00 +0000
+date_end: 2017-11-06 14:00:00 +0000
+banner: 2017_11_06_alexa.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/1822409471120813/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - True Clarity
+---
+
+We're excited to host Nick Hills from Bristol based company True Clarity who will be giving a talk on creating Alexa skills and more!
+
+Pizza involved.
+
+/ Nick Hills: Alexa, spin the wheel?
+
+It’s that time in the morning, the office tea round. But who ‘wins’ the honour of making the round? We could patiently wait for someone to buckle and give in, or we could ask one of our digital sidekicks to spin the wheel of tea fortune. Cloud computing at its full potential? Possibly not, but let us explore the technologies, skills and challenges involved in building your own Alexa skill.
+
+/ About Nick
+
+Nick is a principal developer and Sitecore MVP working at True Clarity. At the moment most days are spent ensuring the AWS infrastructure powering easyJet’s website keeps people flying. His background is mainly web and .net focused however rather enjoys getting stuck in with all kinds of different toys and technologies.
+
+The talk will be in MVB 1.11A from 1-2pm

--- a/_events/2017_11_09_iot.md
+++ b/_events/2017_11_09_iot.md
@@ -1,0 +1,22 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: IoT at Scale
+date:     2017-11-09 13:30:00 +0000
+date_end: 2017-11-09 14:30:00 +0000
+banner: 2017_11_09_iot.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/547482255596601/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: Dyson
+---
+
+The Dyson Connectivity team design, develop and run engaging connected product solutions which are scaling rapidly to meet the global demand. Andy Nesling, Software Engineering Manager, will discuss approaches to the various challenges of scaling an IoT platform, extending our products user interface globally, leveraging a distributed team and moving towards a future of continuous delivery.
+
+As ever, there will be pizza!

--- a/_events/2017_11_14_accessibility_hack.md
+++ b/_events/2017_11_14_accessibility_hack.md
@@ -1,0 +1,39 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Accessibility Hack
+date:     2017-11-14 10:00:00 +0000
+date_end: 2017-11-14 16:30:00 +0000
+banner: 2017_11_14_accessibility_hack.jpg
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/479772452408106/
+ticket_link: https://docs.google.com/forms/d/e/1FAIpQLSc1MPoLjZyon0gsLxIZNLqAMX8HCb-lBQ8PTheM-KljSs7gnQ/viewform
+price: Free
+category:
+    - Competition
+cohost:
+  - company: Bloomberg
+---
+
+You asked for a shorter hackathon: we delivered!
+
+//// ON THE DAY SIGNUP!! //
+https://docs.google.com/forms/d/e/1FAIpQLSc1MPoLjZyon0gsLxIZNLqAMX8HCb-lBQ8PTheM-KljSs7gnQ/viewform
+
+In six hours, it's up to you to build something that makes the world a more accessible place.
+
+What will you build? Here are some ideas to get you started.
+* Screen readers for augmented reality
+* An alternative to mouse and keyboard
+* Eye-tracking interfaces
+* Hearing aids that only relay the most important information
+* A design for privacy settings that children can understand
+There will be food, drinks and prizes (of course!)
+
+//// RULES ////
+https://docs.google.com/document/d/1LGWs2Qy10plUl2lZO4tWFLSG7hMn3qdfLkDXUn97ebg/edit?usp=sharing
+
+//// SIGN UP NOW ////
+https://goo.gl/forms/amhvaj5Qgsgk8KEG3

--- a/_events/2017_11_15_codelounge.md
+++ b/_events/2017_11_15_codelounge.md
@@ -1,0 +1,27 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CodeLounge
+date: 2017-11-15 12:00:00 +0000
+date_end: 2017-11-15 16:00:00 +0000
+banner: 2017_11_15_codelounge.jpg
+location: MVB Lower Atrium
+fb_link: https://www.facebook.com/events/1868800843433282/
+ticket_link:
+price: Free
+category:
+  - Social
+  - Networking
+cohost:
+---
+
+Confused about coding? Crying over your compiler errors? Can't cope with computer conundrums? Confounded by category theory? Clashing with C?
+
+CodeLounge is our communal coursework help and mentoring session. We encourage all freshers to come (undergraduate and masters!) - but everyone is welcome.
+Join us, eat some food and find the fun side of programming #FreeFood
+
+### INTERESTED IN HELPING OUT?
+
+Sign up as a mentor: https://goo.gl/forms/RmCp4blWrTOtyrzz1

--- a/_events/2017_11_15_omg.md
+++ b/_events/2017_11_15_omg.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: ★ CSS explores OMG ★
+date:     2017-11-15 22:00:00 +0000
+date_end: 2017-11-16 03:00:00 +0000
+banner: 2017_11_15_omg.jpg
+location: OMG Bristol
+fb_link: https://www.facebook.com/events/512932889065682/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Bored of coursework? Not had your weekly dose of cheesy pop music? Join CSS in our Explore Week trip to OMG! Bristol’s number one glittery venue, it’s guaranteed to be a night of cheap jager, banger tunes and questionable-quality drag 💃
+Pre with your CS families, then join us at The Berkeley before we stagger/crawl to OMG around midnight. Never been to OMG before? Don’t miss this event with free entry, loads of £1 drinks and Bristol’s number 1 drag queen Tina Sparkle ✨ Glitter is highly encouraged ✨
+
+// Important note //
+OMG is primarily an LGBT+ venue that encourages a welcoming and friendly environment for those who may feel discomfort or face discrimination in other venues. As such we ask that you be respectful of anyone expressing themselves in any way in OMG, and be mindful of language or behaviour that may be interpreted as offensive in this context. Everyone in OMG is there for a great time, and we hope you really enjoy the night too!

--- a/_events/2017_11_16_games.md
+++ b/_events/2017_11_16_games.md
@@ -1,0 +1,26 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSSxCOGS Games and Pizza
+date:     2017-11-16 18:00:00 +0000
+date_end: 2017-11-16 21:30:00 +0000
+banner: 2017_11_16_games.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/200291933845976/
+ticket_link:
+price: Free
+category:
+    - Social
+    - Competition
+cohost:
+    - company: COGS
+---
+
+CSS and COGS meet again for another epic evening of pizza-fuelled gaming. COGS brings the games, and CSS brings the pizza!
+
+With no lectures in Explore Week and free food and drinks throughout the evening, there is no excuse not to come!
+
+In this event, we will be playing Smash, Mario Kart Rocket League, and much more! we will be providing controllers, but feel free to bring your own if you want to.
+

--- a/_events/2017_11_16_lightning.md
+++ b/_events/2017_11_16_lightning.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Lightning Talks
+date:     2017-11-16 14:00:00 +0000
+date_end: 2017-11-16 16:00:00 +0000
+banner: 2017_11_16_lightning.jpg
+location: MVB Lower Atrium
+fb_link: https://www.facebook.com/events/136873833631865
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - Farnoosh Heidarivincheh
+    - Alex Moylett
+    - Chris Hobbs
+    - Kate Bryon
+---
+
+You've seen talks put on by companies in the industry - now get ready for talks given by our very own students and researchers!
+SCHEDULE:
+2:00 - Farnoosh Heidarivincheh - Machine learning action completion
+~2:20 - Alex Moylett - Quantum computers
+~2:40 - Chris Hobbs - Crystal programming language
+~3:00 - Kate Byron - Machine learning

--- a/_events/2017_11_20_ios.md
+++ b/_events/2017_11_20_ios.md
@@ -1,0 +1,41 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Introduction to iOS development
+date:     2017-11-20 13:00:00 +0000
+date_end: 2017-11-20 14:00:00 +0000
+banner: 2017_11_20_ios.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/299944360501872
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Workshop
+cohost:
+    - Jay Lees
+---
+
+To celebrate the opening of the new Hackspace we're running some workshops so that everyone can start getting their hands dirty learning new skills.
+
+Ever wanted to try iOS Dev? How about Augmented Reality or Machine Learning?? Jay Lees has put together some great tutorials for us - come along, grab some pizza and learn something awesome. If you would like to code along then you'll need a Mac with Xcode installed, else you can still come along just to get a feel for it.
+
+Jay plans to cover the following on Monday 20th, with potential to start the next section on the 24th, so save that date too!
+
+1. Introduction to iOS Development
+- Xcode
+- Introduction to the Swift Language
+- Introduction to UI Elements (UITableView, UICollectionView, UIStackView, UIScrollView, UIViewController)
+- Developing a simple application
+- Auto layout
+
+2. Introduction to Augmented Reality for iOS
+- ARKit
+
+3. Introduction to Machine Learning for iOS
+- CoreML
+
+The talk will be in MVB 1.11A from 1-2pm
+

--- a/_events/2017_11_20_pub_quiz.md
+++ b/_events/2017_11_20_pub_quiz.md
@@ -1,0 +1,29 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Pub Quiz
+date:     2017-11-20 18:00:00 +0000
+date_end: 2017-11-20 21:30:00 +0000
+banner: 2017_11_20_pub_quiz.jpg
+location: The Brass Pig
+fb_link: https://www.facebook.com/events/1204844589616861/
+ticket_link:
+price: Free
+category:
+    - Social
+    - Competition
+cohost:
+---
+
+Time has come for a CompSci Pub Quiz! Get yourself in groups of max 5 if you want to take part, why not come with your CSS families and go head to head to see who has the best genes!
+
+With very special host; it's the return of the BEAST, the LEGEND himself and CSS's very own quiz master, HAKEEM!!
+
+Think you have what it takes to be the ultimate CSS pub quiz champions??? Come and have your chance at winning a £25 BAR TAB for your group and MORE!
+
+And, how much is the extravagant event, you say? £1? £10? Like, a bajillion pounds? Nope! Entry is completely FREE! £0 per team! So, why not try your luck?
+
+See your lovely faces at the Brass Pig and be prepared to get quizzical!!
+

--- a/_events/2017_11_24_ios_ar.md
+++ b/_events/2017_11_24_ios_ar.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Introduction to AR for IOS
+date:     2017-11-24 13:00:00 +0000
+date_end: 2017-11-24 14:00:00 +0000
+banner: 2017_11_24_ios_ar.jpg
+location: MVB 1.11(A)
+fb_link: https://www.facebook.com/events/146129342681909/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Workshop
+cohost:
+    - Jay Lees
+---
+
+After Monday's successful workshop Jay has offered to continue his tutorials and teach us a bit about AR! Come along, learn iOS and eat pizza!
+
+If you would like to code along you'll need a Mac with Xcode version 9.0 or newer. A link to code and slides from Monday's session will be posted soon so watch this space.
+
+Jay may potentially follow up with a third workshop on Machine Learning, most probably on another day.
+
+The talk will be in MVB 1.11A from 1-2pm
+

--- a/_events/2017_11_27_ios_workshop_3.md
+++ b/_events/2017_11_27_ios_workshop_3.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Introduction to ML for IOS
+date:     2017-11-27 13:00:00 +0000
+date_end: 2017-11-27 14:00:00 +0000
+banner: 2017_11_27_ios_workshop_3.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/334181540383830/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Workshop
+cohost:
+    - Brendon Warwick
+---
+
+Come along for the grand finale of our iOS workshop series! This one will be taken by Brendon who will guide us through CoreML and the YOLO network! Food will be supplied.
+
+If you would like to code along you'll need a Mac with Xcode version 9.0 or newer.
+
+The materials from the last two workshops can be found [here](https://github.com/jaylees14/IntroToiOS)
+
+The talk will be in MVB 1.11A from 1-2pm
+

--- a/_events/2017_12_01_arm_processor.md
+++ b/_events/2017_12_01_arm_processor.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Next generation arm processors
+date:     2017-12-01 12:00:00 +0000
+date_end: 2017-12-01 13:00:00 +0000
+banner: 2017_12_01_arm_processors.jpg
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/904891876346724
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Careers
+cohost:
+  - company: arm
+---
+
+The talk is held at Merchant Ventures Building, Room 1.11 and 1.11a. There will be food provided like always.
+
+This talk describes the different phases of the processor development at Arm: from the moment it is just a concept on a piece of paper until it is completed and delivered to partners. It shows the different challenges that the engineering teams (performance modeling, design, verification, implementation) need to face. It also details some of the milestones the team needs to achieve during the development phase (from printing “hello world” to booting android). Finally, the talk presents the new Arm LITTLE core, the Cortex A55, released to partners this year which will be part of the next generation mobile phones.
+
+Talk is given by Jose (Pepe) Gonzalez.
+Jose Gonzalez got his Ph.D. in January 2000 at the Universitat Politecnica de Catalunya (UPC), in Barcelona, Spain. After 2 years teaching at the University of Murcia (Spain), in 2002 he joined the new Intel site in Barcelona. He worked 6 years doing research on low power microprocessors, thermal-aware multicores, and accelerators. Then, he moved to the Intel Xeon Phi design team, where he worked on the microarchitecture of the Knights Corner, Knights Landing, and Knights Hill cores. Intel closed the Barcelona site in May 2014 and he moved to Arm, in Cambridge. He has been the MemSys unit lead for the Cortex A55 core and currently, he is the co-technical lead of the new LITTLE core that will come after A55.
+[More info](https://www.linkedin.com/in/pepe-gonzalez-4808621a/)
+
+The talk will be in MVB 1.11 from 12-1
+

--- a/_events/2017_12_05_camera_talk.md
+++ b/_events/2017_12_05_camera_talk.md
@@ -1,0 +1,31 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: What can a wearable camera know about me?
+date:     2017-12-05 12:00:00 +0000
+date_end: 2017-12-05 13:00:00 +0000
+banner: 2017_12_05_camera_talk.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/134516193920282
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - Dima Damen (Senior Lecturer, Department of Computer Science)
+---
+
+Mobile cameras are everywhere; wearable cameras are coming! Current computer vision technology can summarise your day, figure out your routine, even teach you how to perform a new task and remind you if you forgot to switch off the hob after cooking. What are the potentials and limitations of such technology? How mature is it, and when does it fail? This talk will not discuss privacy concerns. It offers a bright outlook into our tech-enhanced future.
+
+[Dima Damen](https://www.cs.bris.ac.uk/~damen/) (Senior Lecturer, Department of Computer Science)
+
+----------------
+
+This definitely isn't one to be missed - talks about new and upcoming tech are always interesting, especially from our very own Senior Lecturer Dima Damen!
+Food provided as always, let us know if you'll be coming by hitting Going!
+
+The talk will be in MVB 1.11A from 12-1pm
+
+![](/assets/images/contrib/events/2017-12-05-dima-talk/cover.jpg)

--- a/_events/2017_12_06_xmas_drinks.md
+++ b/_events/2017_12_06_xmas_drinks.md
@@ -1,0 +1,22 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Christmas Drinks!
+date:     2017-12-06 19:00:00 +0000
+date_end: 2017-12-06 22:00:00 +0000
+banner: 2017_12_06_xmas_drinks.jpg
+location: The Berkeley
+fb_link: https://www.facebook.com/events/1109084015893952
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Take a break from the burden of coursework and exams and come join us for some relaxed drinks at the Berkeley. We'll be there from 7pm till late.
+
+Festive attire is encouraged but by no means essential. 🎅
+

--- a/_events/2018-02-28_boeing_hackathon.md
+++ b/_events/2018-02-28_boeing_hackathon.md
@@ -1,0 +1,103 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: "CSS Boeing Hackathon 2018: Space"
+date:     2018-02-28 11:00:00 +0000
+date_end: 2018-03-01 13:00:00 +0000
+banner: 2018-02-28-boeing-hack/cover.jpg
+location: MVB
+fb_link: $https://www.facebook.com/events/153087555349796/
+ticket_link: https://goo.gl/forms/PFVMp2J89mdVkdRi1
+price: Free
+category:
+    - Social
+    - Networking
+    - Careers
+    - Competition
+cohost:
+  - company: Boeing
+---
+
+**The CSS Boeing Hackathon is back! MVB, 11am Wednesday 28th Feb - 1pm Thursday 1st March**
+
+## SIGNUP
+
+- [Link here](https://goo.gl/forms/PFVMp2J89mdVkdRi1). Teams of up to 6 people
+- Not got anyone to work with or a full team? No worries. Just indicate that you'd like to be matched with others and we'll sort out the rest.
+
+## PRIZES
+
+- 6x Sphero Mini!
+- 6x Google Home Mini!
+- 6x LIFX Smart Lights!
+
+## FREE FOOD AND DRINKS
+
+- If you have any dietary requirements, state them on the signup form or email events@cssbristol.co.uk
+
+## RULES 
+
+- [Can be found here!](https://docs.google.com/document/d/1RXPGyz3aqpJKMluvNhWkN_rSwItzHjIUJPS2jEG26y4/edit?usp=sharing)
+
+## THEME
+
+- Our theme this year is SPACE! 🌌🚀
+
+The prizes will be awarded in three categories:
+
+1. *Space data*
+  - Find a cool way to use satellite imagery or other data collected in space.
+2. *Software/hardware for space*
+  - Build something that we could send into space!
+3. *Explore space*
+  - Help non-scientists to explore and learn about space.
+
+Here are some example projects to get your brains whirring:
+
+-- NEO Mapper
+
+Identifying natural boundaries (rivers) from 3D asteroid surface data
+https://github.com/abbro-ca/VestaRainbow
+https://www.youtube.com/watch?v=DE0qdKAN31A&t=55m
+
+-- Kid On The Moon
+
+Interactive app for children to explore the moon and man’s journeys to it
+https://2016.spaceappschallenge.org/challenges/solar-system/book-it-to-the-moon/projects/kid-on-the-moon
+
+-- NatEv Explorer
+
+Display crowdsourced natural events on a 3D globe
+https://open.nasa.gov/innovation-space/natev-explorer/
+
+-- FractalNet
+
+P2P wearables for communication in space
+https://2016.spaceappschallenge.org/challenges/space-station/rock-it-space-fashion-and-design/projects/fractalnet
+
+-- Pollen Alert
+
+Use open data and satellite imagery to predict pollen count
+https://2017.spaceappschallenge.org/challenges/our-ecological-neighborhood/trace-invaders/teams/lemon-py-1/project
+
+-- Heliox
+
+Use energy and solar radiation data to predict energy production
+https://2017.spaceappschallenge.org/challenges/earth-and-us/you-are-my-sunshine/teams/heliox/project
+
+Maybe you'll write a piece of software that will improve shipping efficiency. How about a system for monitoring air pollution? Or something that will enable autonomous vehicles? Perhaps you'll even write a cool visualisation that uses NASA's Open Data platform (https://opensource.gsfc.nasa.gov/ ).
+
+If you want to make use of satellite data, we'll be releasing some guides to help you soon.
+
+## TOOLS AVAILABLE
+
+- Join the Discord server [here](https://discordapp.com/invite/pt97nDh) for updates on the day!
+- More to come
+
+## GOOD LUCK!
+
+<a class="btn btn--dark" href="https://www.facebook.com/events/153087555349796/">
+    Facebook Event
+</a>

--- a/_events/2018_01_25_end_exams_bar_crawl.md
+++ b/_events/2018_01_25_end_exams_bar_crawl.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: After Exams Bar Crawl
+date:     2018-01-25 20:00:00 +0000
+date_end: 2018-01-26 02:00:00 +0000
+banner: 2018_01_25_end_exams_bar_crawl.jpg
+location: White Harte
+fb_link: https://www.facebook.com/events/2034757046759209/
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/end-of-exams-bar-crawl
+price: £5
+category:
+    - Social
+cohost:
+---
+
+"Let's start our coursework!" Or "Spoons?"
+
+Circle the correct answer, no justification needed. [ 2 marks ]
+
+The route is:
+- White Harte
+- Berkeley
+- Lolas
+
+We'll be selling wristbands over the exam period and the week after in MVB!
+
+Come as your favourite sorting algorithm or in your CSS Tshirt. We have some more from the last bar crawl left over so let us know if you'd like one!

--- a/_events/2018_01_27_aigaming_hack.md
+++ b/_events/2018_01_27_aigaming_hack.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: AIGaming Competition
+date:     2018-01-27 17:30:00 +0000
+date_end: 2018-01-27 22:00:00 +0000
+banner: 2018_01_27_aigaming_hack.png
+location: Queens F101
+fb_link: https://www.facebook.com/events/2048883198657222/
+ticket_link: https://goo.gl/forms/B5i5vwnV8x8nbK203
+price: Free
+category:
+  - Competition
+cohost:
+  - company: AI Gaming
+---
+
+It's our first event of this term! You'll be writing gaming AI bots to compete against a selection of Oxford and Glasgow's finest societies:
+
+* Oxford CodeSoc
+* Oxford AI Society
+* Oxford AI Games Club
+* Glasgow GUTechSoc
+
+You'll be representing your university, so do your best comrade.
+
+[AIGaming](https://www.aigaming.com/) is a platform that lets you win Bitcoin by writing bots to win games like Battleships or Blackjack. We'd recommend getting some practice in - but the challenge on the night will be a mystery!
+

--- a/_events/2018_02_01_pyntsized_python.md
+++ b/_events/2018_02_01_pyntsized_python.md
@@ -1,0 +1,24 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: "Pyntsized Python: A language in an hour"
+date:     2018-02-01 13:00:00 +0000
+date_end: 2018-02-01 14:00:00 +0000
+banner: 2018_02_01_pyntsized_python.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/305430316645179/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+Join us for the first talk/workshop of the year as we explore the best bits of Python! The talk will be taken by Lewis, a fellow CompSci here at Bristol.
+
+Let us know if you're coming, we've got pizza to order!
+
+"Python is more than just a programming language, it's a whole development mindset and ecosystem that offers many advantages to over competing workflows in many situations. Build quickly, run on many platforms and actually enjoy yourself doing it! Join python developer Lewis Bell as he takes you through a whistle-stop tour of the basics of the language, leaving you with a strong foundation for your future in Python Development."
+

--- a/_events/2018_02_14_bae_hack_talk.md
+++ b/_events/2018_02_14_bae_hack_talk.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: How To Hack a Computer
+date:     2018-02-14 13:00:00 +0000
+date_end: 2018-02-14 14:00:00 +0000
+banner: 2018_02_14_bae_hack_talk.jpg
+location: Queens 1.69
+fb_link: https://www.facebook.com/events/546054989086813/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Careers
+cohost:
+  - company: BAE Systems Applied Intelligence
+---
+
+Break hearts on valentines day with your newly earned InfoSec skills! 💔😎
+
+Realise your inner hacker! BAE Systems are dropping by to let us in on some security secrets - save the date!
+
+A good opportunity to learn some skills before the CTF.
+
+Lunch will be provided, ofc
+
+NB: when breaking hearts please only hack VMs or your own personal systems
+

--- a/_events/2018_02_17_bae_ctf.md
+++ b/_events/2018_02_17_bae_ctf.md
@@ -1,0 +1,39 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: BAE CTF
+date:     2018-02-17 09:45:00 +0000
+date_end: 2018-02-17 16:00:00 +0000
+banner: 2018_02_17_bae_ctf.jpg
+location: MVB 1.11
+fb_link: "https://www.facebook.com/events/145809772749008"
+ticket_link: "mailto: ctf@baesystems.com"
+price: Free
+category:
+  - Networking
+  - Careers
+  - Competition
+cohost:
+  - company: BAE Systems Applied Intelligence
+---
+
+///// SEE SIGNUP DETAILS BELOW! /////
+
+BAE Systems Applied Intelligence are running a Capture the Flag event, a day of cyber security challenges and games, on Saturday 17th February 2018. Anybody who is currently enrolled Bristol University can sign up and play. There are prizes for the winning team and goodies for anyone taking part!
+
+The competition is being held in MVB 1.11 and will start at 10:00 and finish at 16:00, with lunch provided by us. We’ll be around all day to provide hints and tips on the challenges and are happy to discuss careers in cyber security and software engineering in BAE Systems Applied Intelligence. If you’re interested please send us an email and sign up!
+
+This is a team-based challenge for teams of 2 to 6 players. If you don’t have a team yet then don’t worry – come along anyway as teams will be created on the day. The challenges will involve breaking into vulnerable websites, cracking ciphers, forensic searches, reverse engineering and much more. No previous experience of these kinds of challenge is necessary; they are designed for students who like taking things apart and seeing how they work.
+
+//// SIGN UP NOW ////
+
+To sign up, please email ctf@baesystems.com from your university email account with the following information:
+
+- Your full name
+- Your team name (if applicable)
+- Your year of study
+- Your course title
+
+If you are signing up on behalf of others, please include the above information for them too. The deadline for signing up is Friday 9th February 2018. We will email you to confirm your place and provide more details on the event and what you need to bring. We really hope to see you there.

--- a/_events/2018_02_22_board_game_night.md
+++ b/_events/2018_02_22_board_game_night.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+cancelled: true
+cancel_reason: This event has been cancelled
+title: Board Games Night
+date:     2018-02-22 18:00:00 +0000
+date_end: 2018-02-22 20:00:00 +0000
+banner: 2018_02_22_board_game_night.jpg
+location: Broad Quay House
+fb_link: https://www.facebook.com/events/140088270137161
+ticket_link:
+price: Free
+category:
+    - Social
+    - Networking
+    - Careers
+cohost:
+    - company: Just Eat
+---
+
+With the help of Just Eat, join us for a magical evening of board games on February 22nd, 6-8pm! ✨Location specifics TBA but it'll be somewhere in Just Eat's office (Broad Quay House, BS1 4DJ).
+Whether you're a master of Catan 🌾 or a novice at Snakes & Ladders 🐍, everyone is welcome. Feel free to bring your own board games. Food and drink will be provided 🙂 🍕🍺

--- a/_events/2018_02_22_pint_of_programming.md
+++ b/_events/2018_02_22_pint_of_programming.md
@@ -1,0 +1,27 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: A Pint of Programming
+date:     2018-02-22 18:00:00 +0000
+date_end: 2018-02-22 22:00:00 +0000
+banner: 2018_02_22_pint_of_programming.jpg
+location: The White Heart
+fb_link: https://www.facebook.com/events/149573015851724
+ticket_link:
+price: Free
+category:
+    - Social
+    - Networking
+cohost:
+---
+
+**Join us at The White Harte Pub for Beer and Programming! 6-10pm 22nd Feb**
+
+Beer + Programming > Programming
+
+White Harte = Beer
+
+Join us at White Heart. Hit the Balmer peak and get coding
+We have the Function Room booked, so don't worry about finding a socket, we have it covered.

--- a/_events/2018_03_01_hashcode.md
+++ b/_events/2018_03_01_hashcode.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: Google Hash Code 2018
+date:     2018-03-01 18:30:00 +0000
+date_end: 2018-03-01 22:30:00 +0000
+banner: 2018_03_01_hashcode.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/2047455662168544/
+ticket_link: https://events.withgoogle.com/hashcode2018-signup/registrations/new/j
+price: Free
+category:
+    - Competition
+cohost:
+  - company: Google
+---
+
+// SIGN UP NOW! //
+https://events.withgoogle.com/hashcode2018-signup/registrations/new/
+You only have until 5pm Monday 26th Feb to sign up so be quick!
+// WHAT IS HASHCODE? //
+Hash Code is an online team programming competition created by Google. The goal is to compete in teams, solving algorithmic challenges inspired by the kind of problems faced at Google.
+The first round is an online competition from 5:30pm to 10:30pm on Thursday 1st March, directly after the Hackathon. We will be hosting a room for your team to compete, and will providing free food, drink, and goodies to fuel you whilst you compete.

--- a/_events/2018_03_02_minecraft.md
+++ b/_events/2018_03_02_minecraft.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS Does Minecraft!
+date:     2018-03-02 16:00:00 +0000
+date_end: 2018-03-02 20:00:00 +0000
+banner: 2018_03_02_minecraft.jpg
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/354833295032432/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Need a calm break from the chaos that is CS? Come spend an afternoon mining iron ore and mass farming virtual chickens with CSS as we run a local Minecraft server!
+Whether you prefer to hit people with fishing rods, or build elaborate mud huts, this event is to help clear your mind of university stress and disappear into a happy world for an afternoon
+Bring along a laptop to join in, snacks will be provided

--- a/_events/2018_03_07_diversity.md
+++ b/_events/2018_03_07_diversity.md
@@ -1,0 +1,38 @@
+---
+layout: event
+published: true
+title: Diversity in STEM
+date:     2018-03-07 13:30:00 +0000
+date_end: 2018-03-07 17:00:00 +0000
+banner: 2018_03_07_diversity.jpg
+location: School of Chemistry
+fb_link: https://www.facebook.com/events/398174470630749/
+ticket_link:
+price: Free
+category:
+    - Networking
+cohost:
+    - Fusion UoB
+    - Bristol University LGBT+ Society
+---
+
+Have you ever felt underrepresented within the STEM (Science, Technology, Engineering, Maths) subject you are studying or want to study? Do you feel that currently, there is very little motivation to address the lack of diversity within STEM subjects?
+We would like you to join us in talking about diversity in STEM and help us to identify positive ways to bring about change.
+This ‘Diversity in STEM’ event will begin with a panel discussion focussed on overcoming barriers to progression and increasing awareness of career opportunities within STEM. Our panel will share their experiences of life as professional within the STEM sector. They belong to traditionally underrepresented groups such as: female (female aligned), BAME (British Black, Asian or Minority Ethnic) or LGBT+ (Lesbian, Gay, Bisexual, Transgender plus).
+Following the discussion, an opportunity for networking with speakers as well as local and national companies who hire STEM graduates.
+Fusion Society is collaborating with societies and departments across the university to bring you our third and final event. This event is open to all. Follow the link to secure a FREE ticket.
+Panellists include:
+Prof Marina Resmini- Chemistry, Queen Mary
+Ms. Teil Howard-Met Office
+Dr. Erinma Ochu -Science communication and future media, University of Salford
+Prof. David K Smith- Chemistry, York University
+Prof. Dorothy Monekosso- Computing, Creative Technologies & Engineering, Leeds Beckett University
+Prof. Uvanney Maylor- Research in Education, University of Bedfordshire
+Ms. Carren Holden- Airbus
+Local Companies attending:
+Edwards Vacuum
+Amec Foster Wheeler/Wood
+AstraZenca
+Rolls-Royce
+Ziylo Ltd.
+Met Office

--- a/_events/2018_03_08_creditcall.md
+++ b/_events/2018_03_08_creditcall.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+title: "Tech Talk: The technology behind payments"
+cancelled: true
+cancel_reason: "Unfortunately we've had to postpone this event - Creditcall has just been acquired and the CTO is a bit busy! We hope to be able to run it some time in the next few weeks."
+date:     2018-03-08 13:00:00 +0000
+date_end: 2018-03-08 14:00:00 +0000
+banner: 2018_03_08_creditcall.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/1212687995531195/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - Creditcall
+---
+
+We'll have Creditcall's CTO here to talk about how modern payments technology works. As always, we will be deploying FREE PIZZA .
+He'll be covering:
+- How payments work and the cutting-edge technology behind them
+- The journey of a transaction from start to finish
+- The FinTech/Payments Industry and why you should want to be in it
+- Security in payments – PCI DSS and PCI P2PE
+---
+Creditcall CTO Jeremy Gumbley (@Jeremy_Gumbley) is a technology entrepreneur and fintech veteran with 20+ years of payment and security experience.
+As a tech innovator, he not only helped Creditcall become one of the first payment gateways in Europe but also facilitated the company’s PCI DSS Level 1 compliance, one of the very first payment gateways to achieve that level. Recognizing the significant impact EMV would have in the future, he directed the development of Creditcall’s EMV Kernel Portfolio. In 2014, he was pivotal in making Creditcall the first EMV-ready payment gateway to the US.

--- a/_events/2018_03_08_rights.md
+++ b/_events/2018_03_08_rights.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: "Big Brother Watch: Championing Civil Rights in the Digital Age"
+date:     2018-03-08 17:15:00 +0000
+date_end: 2018-03-08 18:15:00 +0000
+banner: 2018_03_08_rights.jpg
+location: Wodehouse LT, 35 Berkeley Square
+fb_link: https://www.facebook.com/events/350414128790680/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - International Affairs Society
+---
+
+Come to the first event in our series "Digital Dilemma", co-hosted by the International Affairs Society and Computer Science Society, which will include a talk, a panel and a debate on the role of technologies in numerous aspects of our life ranging from data ownership to the digitisation of labour and warfare.
+Our first talk is led by Big Brother Watch, a civil advocacy organization whose goal is to ensure that those who fail to respect our privacy, undermine our online security, or fail to protect our personal data, – be it the government, public authorities or businesses – are held to account.
+Who should control your data? You? The government? Facebook/Google?
+The discussion will cover the cases and campaigns Big Brother is involved in (check them out here: https://bigbrotherwatch.org.uk/campaigns/), as well as the state of the legislation on citizens' privacy online – including the notorious Investigatory Powers Act and the upcoming EU General Data Protection Legislation.

--- a/_events/2018_03_14_digital_dilemma.md
+++ b/_events/2018_03_14_digital_dilemma.md
@@ -1,0 +1,26 @@
+---
+layout: event
+published: true
+title: "Technological Revolution: Implications for Democracy | The Digital Dilemma"
+date:     2018-03-14 17:15:00 +0000
+date_end: 2018-03-14 19:15:00 +0000
+banner: 2018_03_14_digital_dilemma.jpg
+location: 1.15 Queens Building
+fb_link: https://www.facebook.com/events/341100409724737/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Debate
+cohost:
+---
+
+Join us on Wednesday 14 March for the #DigitalDilemma event #2!
+An academic panel including speakers from SPAIS (Sociology, Politics and Int'l Studies), Law, and Computer Science Schools will be discussing how technology is shaping our societies, both positively and negatively – including through the digitisation of elections, predictive analysis & use of data by law enforcement, creation of "cyberweapons", and many more.
+Is technology a curse or a blessing for democratic (and not-so) societies? What safety measures – political, legal and technical – do we need in place to ensure the setbacks of such a fast-pace development are minimised?
+These and other questions will be posed to our speakers:
+• Dr Miranda Mowbray (CSS);
+• Ms Clare Stevens (SPAIS);
+• Mr Kit Fotheringham (Law);
+• Dr David Bernhard (CSS).
+See you there – we're anticipating a very diverse range of perspectives covered!

--- a/_events/2018_03_15_mvball.md
+++ b/_events/2018_03_15_mvball.md
@@ -1,0 +1,32 @@
+---
+layout: event
+published: true
+title: MVBAll 2018
+cancelled: false
+cancel_reason:
+date:     2018-03-15 19:00:00 +0000
+date_end: 2018-03-16 00:00:00 +0000
+banner: 2018_03_15_mvball.jpg
+location: Mercure Bristol Grand Hotel
+fb_link: https://www.facebook.com/events/405270823261270/
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/mvball-2018
+price: £29
+category:
+    - Social
+cohost:
+    - company: BEEES
+    - Women in Engineering
+---
+
+Tickets are now sold out! We look forward to seeing you all there!
+-----------------------------
+CSS, Women in Engineering and BEEES are excited to announce our first ever MVBall!
+Fancy a night of wine, fine dining, getting smashed in suits and hammered in heels?
+Tickets will be £29 and include:
+- A 2 course dinner, including tea, coffee and mints
+- Half a bottle of house wine with dinner
+- Roaming Photographer
+- DJ
+- Popcorn and Candyfloss machine!
+
+Dress Code: Black tie

--- a/_events/2018_03_15_units.md
+++ b/_events/2018_03_15_units.md
@@ -1,0 +1,24 @@
+---
+layout: event
+published: true
+title: Units Choice Exhibition
+date:     2018-03-15 13:00:00 +0000
+date_end: 2018-03-15 14:00:00 +0000
+banner: 2018_03_15_units.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/2074935179456448/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+You asked for it, you waited for it for a long time
+Now, We are pleased to announce that for the first time we're organising a Units Choice Event
+For a long time, students could not get a real feedback from each other and understand which unit they definitely would like to do and which is not their kind .
+Now, you have this opportunity to get a real feedback from your peers and friends, or even more excitingly, you can share your own one!
+If you want to hear a feedback about specific unit(s), you are welcome to tell us about them using this form:
+https://goo.gl/forms/tvzppaqyISJZw3kU2
+Besides, If you think your opinion and experience (good/neutral/bad) must be shared with other students about particular unit(s) and you would like do so, tell us about it using the same form, as above.
+Free pizza will be provided!

--- a/_events/2018_03_16_bloomberg_ml.md
+++ b/_events/2018_03_16_bloomberg_ml.md
@@ -1,0 +1,34 @@
+---
+layout: event
+published: true
+title: "Tech Talk: Read Less, Learn More"
+cancelled: false
+cancel_reason:
+date:     2018-03-16 12:00:00 +0000
+date_end: 2018-03-16 13:00:00  +0000
+banner: 2018_03_16_bloomberg_ml.jpg
+location: Queens 1.6
+fb_link: https://www.facebook.com/events/765656633631852/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost: 
+  - company: Bloomberg
+---
+
+Come to Queens 1.6 at 12pm on March 16th for a talk by Bloomberg on machine learning and natural-language processing (with, of course, free food 🍕)!
+
+---
+
+The Bloomberg Terminal brings together real-time data on every market, breaking news, in-depth research, powerful analytics in one fully integrated solution. In the News product, we provide, our award-winning news coverage ensures our clients could get the information they need. While at the same time, putting a lot of effort into trying to avoid overloading them with excessive information.
+
+With more than 2,700 in-house news professional, and 1000 external news sources, our clients are bombarded with massive volume of text every moment, and becoming less able to understand markets and effectively make decisions based on them.
+
+In this talk, we will look into this issue and go over how Bloomberg scientists designed a system that is able to refine information from a massive amount of news stories. We will discuss the ML/NLP techniques that underpin it, and illustrate extraction results from recent news articles.
+
+Finally, we will discuss what are the other potential applications of such a system.
+
+---
+
+Iat Chong Chan is a research scientist/software developer in Bloomberg Machine Learning Team. His interests mostly lie in the intersection of Computational Linguistics, Machine Learning, and High Performance Computing. He has been working on a scalable infrastructure to infer topics of social contents ingested to Bloomberg by statistical models, and a multi-documents summarisation system to extract the most important information from a text collection. Iat Chong also leads the NLP guild inside Bloomberg, to advocate the use of ML/NLP techniques for new business problems. Before he joined the company, he was a MSc student in Dept. of Computer Science at University of Oxford, supervised by Prof. Stephen Pulman and Yishu Miao, and worked on building a better input method on small hand-held devices by a novel Bayesian Network with Variational Inference.

--- a/_events/2018_03_29_data_debate.md
+++ b/_events/2018_03_29_data_debate.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+title: "Debate: AI, Media & our obsession with Data"
+cancelled: false
+cancel_reason:
+date:     2018-03-20 17:15:00 +0000
+date_end: 2018-03-20 18:30:00 +0000
+banner: 2018_03_20_debate.jpg
+location: 1.68 Queens
+fb_link: https://www.facebook.com/events/1667979293295515
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+    - Debate
+cohost:
+---
+
+Join us on Tuesday for the third & the last #DigitalDilemma event! A debate between Professor Nello Cristianini and Dr Carl Henrik Ek (CSS) will cover the perks and perils of our obsession with Data.
+The combination of machine learning and big data has enabled us to create a new generation of Artificial Intelligence, and now we interact with its applications daily. This means that the AI agents are in the position to observe a large portion of our activities, but also creates a new type of risk – e.g. surveillance and manipulation of user behaviour.
+Freaked out by the reports on psychometric election targeting and predictive analysis in criminal justice?
+This debate might be a perfect opportunity to listen to our speakers debunking – or confirming – these fears.

--- a/_events/2018_04_11_agm.md
+++ b/_events/2018_04_11_agm.md
@@ -1,0 +1,50 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title:  "AGM 2018"
+date:     2018-04-18 17:15:00 +0100
+date_end: 2018-04-18 18:45:00 +0100
+banner: 2018_04_11_agm.jpg
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/356362618213335/
+ticket_link:
+price: Free
+category:
+    - Careers
+---
+
+It's that time of year again! Come to the CSS AGM for free pizza and a free vote.
+
+---
+
+We'll be electing twelve new committee members. You can nominate yourself for multiple positions, and elections will happen in this order:
+
+- President
+- Vice-President
+- Treasurer
+- Secretary
+- Events
+- Press
+- Webmaster
+- Sports and Social
+- Outreach
+- Equality and Diversity
+- General Officers (x2)
+
+You will have a chance to speak for 60s (once, regardless of how many positions you apply for) during the AGM.
+
+If you're abroad this year or can't attend the AGM - don't worry! You can still apply. We recommend recording a short video of yourself speaking so that we can play it at the AGM. If you like, we can read out a written statement instead.
+
+Could you see yourself at the helm of our next Hackathon or Bar Crawl? Being a committee member is a great way to gain experience running events, dealing with industrial sponsors and communications. And to boot - it's a whole lot of fun!
+
+Have questions about what it's like to be a CSS committee member? [Ask any of us!](https://cssbristol.co.uk/contact/)
+
+[Apply for a position!](https://goo.gl/forms/935LJiynSu6a1UZk1)
+
+---
+
+Want to make a change to how the society runs? Put forward a motion to change our [constitution](https://cssbristol.co.uk/constitution). Constitutional changes must receive a two-thirds majority. Non-constitutional motions must receive a majority.
+
+[Submit a motion!](https://goo.gl/forms/935LJiynSu6a1UZk1)

--- a/_events/2018_06_02_bbq.md
+++ b/_events/2018_06_02_bbq.md
@@ -1,0 +1,31 @@
+---
+layout: event
+published: true
+title: 2018 Summer BBQ
+cancelled: false
+cancel_reason:
+date:     2018-06-02 12:00:00 +0100
+date_end: 2018-06-02 18:00:00  +0100
+banner: 2018_06_02_bbq.jpg
+location: Brandon Hill
+fb_link: https://www.facebook.com/events/177790673047577/
+ticket_link: https://www.eventbrite.co.uk/e/css-bbq-2018-tickets-45797393236
+price: Free
+category:
+    - Social
+cohost: 
+---
+
+The annual CSS BBQ is upon us again!
+
+Join us as we continue the annual tradition marking the end of a busy year (and the end of exams!)
+
+Come for free food, drink and lots of entertainment!
+
+* **Location:** Berkeley Square, Bristol
+* **Date:** June 2, midday
+
+[Remember to book your free ticket through Eventbrite](https://www.eventbrite.co.uk/e/css-bbq-tickets-25051709337)
+
+* [Join the Facebook event](https://www.facebook.com/events/177790673047577/)
+* [Save the Google Calendar entry](https://calendar.google.com/calendar/render?eid=aWc0YnQ0dW1ncnRvOXQ0Z3QwM29idHZqdTAgY3NzYnJpc3RvbC5jby51a19jbW1iNzdpNGtkNmQ5b2tmdjVuYzFwaWJuMEBn)

--- a/_events/2018_09_24_welcome.md
+++ b/_events/2018_09_24_welcome.md
@@ -1,0 +1,18 @@
+---
+layout: event
+published: true
+title: CSS Welcome Drinks 2018
+date:     2018-09-24 18:00:00 +0100
+date_end: 2018-09-24 23:00:00 +0100
+banner: 2018_09_24_welcome.jpg
+location: The White Harte
+fb_link: https://www.facebook.com/events/1008064936065177/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Welcome (back) to uni!
+Join us at at the White Harte for drinks, board games, and a good opportunity to meet people on your course. 🍻

--- a/_events/2018_09_27_family.md
+++ b/_events/2018_09_27_family.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+title: CSS Family Meetup
+date:     2018-09-27 13:00:00 +0100
+date_end: 2018-09-27 16:30:00 +0100
+banner: 2018_09_27_family.jpg
+location: MVB
+fb_link: https://www.facebook.com/events/1136630049846877/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+All new first-year CS students are invited to come along and meet their Computer Science parents. It'll be informal with free food 🥪 and board games 🎲 so please come!
+
+New post-grads are also welcome to come along and socialise in MVB 1.11
+
+WHERE: Merchant Venturer's Building, bottom floor
+WHEN: 1pm
+
+If you want to be a parent, sign up here:
+https://docs.google.com/forms/d/e/1FAIpQLSfz3E9h6Nx03MgSkW683RVaHN3xWbUUURrI2VuWOnTqOeiefw/viewform?usp=sf_link
+(Sign up deadline is 22nd September, 12:00pm)
+
+First-years are automatically made children, so don't worry about signing up for anything.

--- a/_events/2018_10_04_scavenger.md
+++ b/_events/2018_10_04_scavenger.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+title: Family Scavenger Hung
+date:     2018-10-04 20:30:00 +0100
+date_end: 2018-10-04 22:30:00 +0100
+banner: 2018_10_04_scavenger.jpg
+location: The Berkeley Wetherspoons
+fb_link: https://www.facebook.com/events/2192281860991041/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Hey all!
+
+Nothing brings people closer together than slightly odd stories.
+So, we have organised a scavenger hunt for you this Thursday.
+Get into your families or other groups of friends and see if you can get enough points to win top prize!
+
+The actual hunt starts at 9pm, so make sure you come early (8:30pm) to prepare.
+
+SNEEK PEEK OF SOME QUESTIONS:
+- Get a complete (non CSS) stranger to stand on their chair (10 points)
+- Stack 5 pint glasses (5 points)
+- Get your whole team to drink out of the same drink simultaneously (5 points)

--- a/_events/2018_10_11_git.md
+++ b/_events/2018_10_11_git.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+title: Intro To Git
+date:     2018-10-11 13:00:00 +0100
+date_end: 2018-10-11 14:00:00 +0100
+banner: 2018_10_11_git.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/345279159369573/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+Welcome to our first talk of the year!
+Our very own David Bernhard will be giving an introductory talk on how to use Git, aimed at first-years (but everyone is welcome)
+
+There will be free pizza 🍕 as always (& vegan/gf alternatives 🥙 - see poll in discussion).
+
+Not able to go to the talk? Relevant notes are available here:
+www.ole.bris.ac.uk/bbcswebdav/users/csxdb/pub/git/

--- a/_events/2018_10_15_silicon_valley.md
+++ b/_events/2018_10_15_silicon_valley.md
@@ -1,0 +1,19 @@
+---
+layout: event
+published: true
+title: Talk - Silicon Valley
+date:     2018-10-15 13:00:00 +0100
+date_end: 2018-10-15 14:00:00 +0100
+banner: 2018_10_15_silicon_valley.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/697987123906446/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+Two graduates from the University of Bristol, Tom Alterman and Callum Muir, will be speaking about careers and internships in Silicon Valley.
+
+Free food? Of course. See the poll in discussion for any specific dietary requirements.

--- a/_events/2018_10_16_python_bloomberg.md
+++ b/_events/2018_10_16_python_bloomberg.md
@@ -1,0 +1,32 @@
+---
+layout: event
+published: true
+title: Declarative Software Design in Python by Bloomberg
+date:     2018-10-16 13:00:00 +0100
+date_end: 2018-10-16 14:00:00 +0100
+banner: 2018_10_16_python_bloomberg.png
+location: Queens 1.15
+fb_link: https://www.facebook.com/events/1820133684772325/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - company: Bloomberg
+---
+
+📍 WHERE: Queens Building, 1.15
+🕐 WHEN: 13:00-13:50
+
+Elmer Landaverde from Bloomberg, one of our sponsors, is coming down to give a talk!
+
+Free food as always, see the poll in discussion for any specific dietary requirements.
+
+## FULL TALK DESCRIPTION:
+Our team deals with very complex business rules. We need to create services that can continue to take on more business complexity while keeping the code maintainable.
+
+This has driven us to design software that is declarative in nature instead of imperative (along the lines of how ReactJS treats UI state). The advantage is that we get to isolate business logic to a stateless configuration file thus separating business logic from infrastructure logic.
+
+Our talk will focus on this design and when may want to choose this approach.
+
+Speaker: Elmer Landaverde - Team Leader in our Engineering Core Workflow Team.

--- a/_events/2018_10_16_sciences_bar_crawl.md
+++ b/_events/2018_10_16_sciences_bar_crawl.md
@@ -1,0 +1,34 @@
+---
+layout: event
+published: true
+title: Sciences Bar Crawl 2018
+date:     2018-10-16 21:00:00 +0100
+date_end: 2018-10-17 04:00:00 +0100
+banner: 2018_10_16_sciences_bar_crawl.jpg
+location: Berkeley Wetherspoons
+fb_link: https://www.facebook.com/events/1773642616018649/
+ticket_link:
+price: £7
+category:
+    - Social
+cohost:
+    - Sciences Bar Crawl
+---
+
+Join us on the Sciences Bar Crawl!
+
+Route:
+- 21.00 Berkeley Wetherspoons
+- 22.00 Agora
+- 23.00 Revolution Bar
+- 0.00 SWX
+
+We'll be doing the route with:
+- EFM
+- BioMed
+- Vets
+- Social Policy
+- Electrical Engineering
+- Neuroscience
+- Medicine
+- Anatomy

--- a/_events/2018_10_18_arduino.md
+++ b/_events/2018_10_18_arduino.md
@@ -1,0 +1,41 @@
+---
+layout: event
+published: true
+title: Intro to Arduino - Workshop Session 1
+date:     2018-10-18 13:00:00 +0100
+date_end: 2018-10-18 14:00:00 +0100
+banner: 2018_10_18_arduino.jpg
+location: MVB Hackspace
+fb_link: https://www.facebook.com/events/497121244098896/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Workshop
+cohost:
+  - company: BEEES
+  - company: Innovation Design Soc
+---
+
+Welcome to the third session of the Intro to Arduino - Mech-Elec workshop of the Innovation Design Society!
+
+In this one, we'll be introducing a very basic Ardunio project to students interested in getting started with Arduino electronic prototyping. We assume absolutely no previous experience at all so join along!
+
+By the end of the session you should be able to:
+
+- Understand the potential of Arduino Prototyping
+- Use the Ardunio IDE to write/understand the basics of a Arduino language/C++ script and its control power over the board's internal electronics components.
+- Understand and prototype with servos, buttons, breadboards, jumper wires to build a basic servo controller.
+- Not blow anything up.
+
+Signups are on a first-register/attend-in-time basis and spaces are limited to 18 people - and we're using the tickets to keep track - the event is absolutely free of course. The first 18 people who've got a free register ticket have a guaranteed spot if they arrive within the first 10 mins of the session, if not their spot will be available to the other post-cap attendees. If the events are popular, we'll run more sessions so don't worry - it will only be another day!
+
+Alternative Sessions Proposals
+https://goo.gl/forms/hiZfQJAa05dkaeBY2
+
+Resources for the Workshop:
+Intro to Arduino - https://www.arduino.cc/en/Guide/Introduction
+Overall View of Arduino Potential - https://create.arduino.cc/projecthub
+Install IDE on the computer or Online - https://www.arduino.cc/en/Main/Software
+Servo Wiring - http://www.fatlion.com/sailplanes/servos.html
+Servo-Button-Ardunino Controller Tutorial - https://create.arduino.cc/projecthub/glowascii/servo-arduino-basics-cb9266?ref=search&ref_id=basics&offset=4

--- a/_events/2018_10_19_arduino.md
+++ b/_events/2018_10_19_arduino.md
@@ -1,0 +1,41 @@
+---
+layout: event
+published: true
+title: Intro to Arduino - Workshop Session 2
+date:     2018-10-19 13:00:00 +0100
+date_end: 2018-10-19 14:00:00 +0100
+banner: 2018_10_19_arduino.jpg
+location: MVB Hackspace
+fb_link: https://www.facebook.com/events/928769453980668/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Workshop
+cohost:
+  - company: BEEES
+  - company: Innovation Design Soc
+---
+
+Welcome to the third session of the Intro to Arduino - Mech-Elec workshop of the Innovation Design Society!
+
+In this one, we'll be introducing a very basic Ardunio project to students interested in getting started with Arduino electronic prototyping. We assume absolutely no previous experience at all so join along!
+
+By the end of the session you should be able to:
+
+- Understand the potential of Arduino Prototyping
+- Use the Ardunio IDE to write/understand the basics of a Arduino language/C++ script and its control power over the board's internal electronics components.
+- Understand and prototype with servos, buttons, breadboards, jumper wires to build a basic servo controller.
+- Not blow anything up.
+
+Signups are on a first-register/attend-in-time basis and spaces are limited to 18 people - and we're using the tickets to keep track - the event is absolutely free of course. The first 18 people who've got a free register ticket have a guaranteed spot if they arrive within the first 10 mins of the session, if not their spot will be available to the other post-cap attendees. If the events are popular, we'll run more sessions so don't worry - it will only be another day!
+
+Alternative Sessions Proposals
+https://goo.gl/forms/hiZfQJAa05dkaeBY2
+
+Resources for the Workshop:
+Intro to Arduino - https://www.arduino.cc/en/Guide/Introduction
+Overall View of Arduino Potential - https://create.arduino.cc/projecthub
+Install IDE on the computer or Online - https://www.arduino.cc/en/Main/Software
+Servo Wiring - http://www.fatlion.com/sailplanes/servos.html
+Servo-Button-Ardunino Controller Tutorial - https://create.arduino.cc/projecthub/glowascii/servo-arduino-basics-cb9266?ref=search&ref_id=basics&offset=4

--- a/_events/2018_10_23_arduino.md
+++ b/_events/2018_10_23_arduino.md
@@ -1,0 +1,41 @@
+---
+layout: event
+published: true
+title: Intro to Arduino - Workshop Session 3
+date:     2018-10-23 13:00:00 +0100
+date_end: 2018-10-23 14:00:00 +0100
+banner: 2018_10_23_arduino.jpg
+location: MVB Hackspace
+fb_link: https://www.facebook.com/events/213255372751191/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+  - Workshop
+cohost:
+  - company: BEEES
+  - company: Innovation Design Soc
+---
+
+Welcome to the third session of the Intro to Arduino - Mech-Elec workshop of the Innovation Design Society!
+
+In this one, we'll be introducing a very basic Ardunio project to students interested in getting started with Arduino electronic prototyping. We assume absolutely no previous experience at all so join along!
+
+By the end of the session you should be able to:
+
+- Understand the potential of Arduino Prototyping
+- Use the Ardunio IDE to write/understand the basics of a Arduino language/C++ script and its control power over the board's internal electronics components.
+- Understand and prototype with servos, buttons, breadboards, jumper wires to build a basic servo controller.
+- Not blow anything up.
+
+Signups are on a first-register/attend-in-time basis and spaces are limited to 18 people - and we're using the tickets to keep track - the event is absolutely free of course. The first 18 people who've got a free register ticket have a guaranteed spot if they arrive within the first 10 mins of the session, if not their spot will be available to the other post-cap attendees. If the events are popular, we'll run more sessions so don't worry - it will only be another day!
+
+Alternative Sessions Proposals
+https://goo.gl/forms/hiZfQJAa05dkaeBY2
+
+Resources for the Workshop:
+Intro to Arduino - https://www.arduino.cc/en/Guide/Introduction
+Overall View of Arduino Potential - https://create.arduino.cc/projecthub
+Install IDE on the computer or Online - https://www.arduino.cc/en/Main/Software
+Servo Wiring - http://www.fatlion.com/sailplanes/servos.html
+Servo-Button-Ardunino Controller Tutorial - https://create.arduino.cc/projecthub/glowascii/servo-arduino-basics-cb9266?ref=search&ref_id=basics&offset=4

--- a/_events/2018_10_23_bar_crawl.md
+++ b/_events/2018_10_23_bar_crawl.md
@@ -1,0 +1,36 @@
+---
+layout: event
+published: true
+title: CSS Bar Crawl 2018
+date:     2018-10-23 20:00:00 +0100
+date_end: 2018-10-24 04:00:00 +0100
+banner: 2018_10_23_bar_crawl.png
+location: The White Harte
+fb_link: https://www.facebook.com/events/348909932346928/
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/css-annual-bar-crawl
+price: £5
+category:
+    - Social
+cohost:
+---
+It's that time of year again! Get your t-shirt and join us on the 2018 CSS Bar Crawl.
+
+👕🎽 GET YOUR T-SHIRT NOW 👚👔
+https://www.bristolsu.org.uk/groups/computer-science-society/events/css-annual-bar-crawl
+DEADLINE: 19th Oct, 11:59pm
+
+For £5 you get:
+✨ An INCREDIBLY EXCLUSIVE bar crawl t-shirt
+✨ Guest list entry into Lola Los
+✨ Access to the VIP area
+🥂 Free bubbly
+📸 Professional photography for the night
+
+8.00pm - The White Harte
+9.00pm - The Berkeley
+10.00pm - Mbargo
+10.45pm - Lola Lo
+
+👨‍👩‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧👨‍👨‍👦👨‍👨‍👦‍👦👩‍👦‍👦  👨‍👩‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧👨‍👨‍👦👨‍👨‍👦‍👦👩‍👦‍👦
+It's a great idea to get into your FAMILIES, or adopted families, for a dinner to prepare for the crawl!
+👨‍👩‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧👨‍👨‍👦👨‍👨‍👦‍👦👩‍👦‍👦  👨‍👩‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧👨‍👨‍👦👨‍👨‍👦‍👦👩‍👦‍👦

--- a/_events/2018_10_27_cogs_lan.md
+++ b/_events/2018_10_27_cogs_lan.md
@@ -1,0 +1,22 @@
+---
+layout: event
+published: true
+title: CSSxCOGS Lan Party
+date:     2018-10-27 10:00:00 +0100
+date_end: 2018-10-28 10:00:00 +0100
+banner: 2018_10_27_cogs_lan.jpg
+location: MVB
+fb_link: https://www.facebook.com/events/1849433995126346/
+ticket_link:
+price: £2
+category:
+    - Competition
+cohost:
+    - company: COGS
+---
+
+First COGS LAN of the year, joint with the Computer Science Society in MVB 1.11 for 24 hours.
+
+Entry is free for members, otherwise £2 on the door or through the SU website here: https://www.bristolsu.org.uk/groups/cogs-computer-gaming-society/events/cogs-css-lan-party-payment
+
+You will need to bring your own PC/Laptop and monitor, and we also welcome people bringing consoles. We will also be providing a few consoles like at our Console Socials, so you can come even without a PC!

--- a/_events/2018_10_31_netflix_and_thrill.md
+++ b/_events/2018_10_31_netflix_and_thrill.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: Netflix and Thrill
+date:     2018-10-31 16:00:00 +0100
+date_end: 2018-10-31 18:00:00 +0100
+banner: 2018_10_31_netflix_and_thrill.jpg
+location: Chemistry LT3
+fb_link: https://www.facebook.com/events/257145254998782/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Hey all! You can't celebrate Halloween without "enjoying" a horror!
+
+So we'll be showing a horror film this Wednesday in Chemisty: Lecture Theater 3 (for educational purposes)
+🎥🎬🧛🧛
+
+There will be lots of popcorn and various snacks!
+🍿🍿🥨🍧🍰🍬🍭
+
+PS. You can always bring work with you and hide behind your screen if you're too scared.

--- a/_events/2018_11_01_ghyston.md
+++ b/_events/2018_11_01_ghyston.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: Meet the Devs at Ghyston
+date:     2018-11-01 16:00:00 +0000
+date_end: 2018-11-01 22:00:00 +0000
+banner: 2018_11_01_ghyston.jpg
+location: Cosy Club
+fb_link: https://www.facebook.com/events/269730347013197/
+ticket_link:
+price: Free
+category:
+    - Networking
+cohost:
+  - company: Ghyston
+---
+
+📍 WHERE: Cosy Club, 31 Corn St, BS1 1HT
+🕐 WHEN: 16:00-22:00
+
+This event is facilitated by University of Bristol Careers Service.

--- a/_events/2018_11_01_visa.md
+++ b/_events/2018_11_01_visa.md
@@ -1,0 +1,20 @@
+---
+layout: event
+published: true
+title: Visa Talk
+date:     2018-11-01 13:00:00 +0000
+date_end: 2018-11-01 14:00:00 +0000
+banner: 2018_11_01_visa.jpg
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/332282504213401/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+  - company: VISA
+---
+
+Philip Adler, visiting from Visa, will speak about the skills which are important to being a good software engineer, how conceptual understanding best aids software engineering in large companies like Visa, and the kinds of approaches that aid software engineers in their day to-day.
+
+This promises to be another useful and interesting talk; please tap GOING so that we buy enough 🍕🥙!

--- a/_events/2018_11_09_codecon.md
+++ b/_events/2018_11_09_codecon.md
@@ -1,0 +1,27 @@
+---
+layout: event
+published: true
+title: Bloomberg CodeCon 2018
+date:     2018-11-09 17:30:00 +0000
+date_end: 2018-11-09 20:30:00 +0000
+banner: 2018_11_09_codecon.jpg
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/331538004319329/
+ticket_link: http://tinyurl.com/yd3cyvjc
+price: Free
+category:
+    - Competition
+cohost:
+  - company: Bloomberg
+---
+
+Open to all coders, CodeCon is a Global programming contest developed by
+Bloomberg Engineers. Solve as many problems as you can to win an all expensed
+trip to London for the Finals! Compete in C, C ++, Java, Python, C #, Javascript,
+Scala, Rust or Ruby. Push your programming and problem solving skills to the limit
+and race against the clock to win the title of Bloomberg CodeCon Champion!
+
+Register for CodeCon now:
+http://tinyurl.com/yd3cyvjc
+
+As always, there will be food & drinks 🍕🥙 - make sure to hit 'going' on the FB event!

--- a/_events/2018_11_15_unity.md
+++ b/_events/2018_11_15_unity.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: Intro to Unity | Explore Week
+date:     2018-11-15 13:00:00 +0000
+date_end: 2018-11-15 14:00:00 +0000
+banner: 2018_11_15_unity.jpg
+location: MVB 1.11/1.11A
+fb_link: https://www.facebook.com/events/192116811675695/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+Ibrahim Qasim is giving an introductory talk on how to use Unity, intended for 1st and 2nd years.
+
+The perfect introduction for the Gamejam.
+
+As always, remember to hit 'going' so we know how much food to get!

--- a/_events/2018_11_16_egm.md
+++ b/_events/2018_11_16_egm.md
@@ -1,0 +1,51 @@
+---
+layout: event
+published: true
+title: EGM
+date:     2018-11-16 17:00:00 +0000
+date_end: 2018-11-16 18:15:00 +0000
+banner: 2018_11_16_egm.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/257931891735669/
+ticket_link:
+price: Free
+category:
+    - Networking
+cohost:
+---
+
+VOTING LINKS (use Bristol email):
+* Motion 1: http://bit.ly/cssegmmot1
+* Motion 2: http://bit.ly/cssegmmot2
+* First Year Rep: http://bit.ly/cssegmfirstyr
+* Press Officer: http://bit.ly/cssegmpress
+
+These will individually close after their round for voting finishes at the EGM.
+
+---
+
+NOMINATE YOURSELF FOR PRESS OFFICER:
+https://goo.gl/forms/JRR7sa1HsEsUpyZG2
+
+SUBMIT A MOTION:
+https://goo.gl/forms/GRU0la0wE71QHGIk2
+
+---
+
+We're holding an EGM to vote on the first-year rep elections and potentially elect a new press-officer.
+
+Submitted motions will be discussed and voted on; the first-year rep role voted on (nominations were open previously in the year); and a vote of no confidence will be raised for the press officer role.
+If the no confidence vote passes, the submitted nominations will be voted on. If not, the submitted nominations will be discarded.
+
+You'll have a chance to speak for 60s per nomination during the EGM.
+
+All forms will close 24h before the EGM (15/11/18 17:00:00).
+If you can't come then an online voting form will be available 24 hours before the event (link coming soon).
+
+As always, free food will be provided.
+
+Have questions about what it's like to be a CSS committee member? Ask any of us! https://cssbristol.co.uk/contact/
+
+---
+
+Want to make a change to how the society runs? Put forward a motion to change our constitution (https://cssbristol.co.uk/constitution). Constitutional changes must receive a two-thirds majority. Non-constitutional motions must receive a majority.

--- a/_events/2018_11_19_gamejam.md
+++ b/_events/2018_11_19_gamejam.md
@@ -1,0 +1,44 @@
+---
+layout: event
+published: true
+title: Game Jam | Explore Week
+date:     2018-11-19 10:00:00 +0000
+date_end: 2018-11-20 14:00:00 +0000
+banner: 2018_11_19_gamejam.jpg
+location: MVB
+fb_link: https://www.facebook.com/css.bristol.9/events/admin/
+ticket_link:
+price: Free
+category:
+    - Competition
+cohost:
+---
+Our 24h in-house Gamejam is here.
+
+/// VIEW ON ITCH NOW ///
+itch.io/jam/cssgj
+
+# Theme:
+It's a secret!
+
+# Rules (tl;dr-edition):
+* Teams of up to 6 people
+    -> Teams made of 50% or more committee **cannot** win
+* Use whatever engine you like
+    -> Judging will take the complexity into account, however
+
+---
+
+# Q&A:
+- I don't have a team!
+    - That's OK! We'll team you up with some other people :)
+- I don't feel skilled enough to participate!
+    - You probably are! A lot of time spent in hackathons is spent on learning - first years have won in the past
+- I don't have a good game idea!
+    - Have a look at some other games for inspiration; copy an existing game; or use this idea generator: http://orteil.dashnet.org/gamegen
+- Will there be free pizza?
+    - You know it.
+
+---
+
+Make sure to go to the Games Industry Panel event too (1 hour before the start)!

--- a/_events/2018_11_19_panel.md
+++ b/_events/2018_11_19_panel.md
@@ -1,0 +1,17 @@
+---
+layout: event
+published: true
+title: Game Industry Panel | Explore Week
+date:     2018-11-19 10:00:00 +0000
+date_end: 2018-11-19 11:00:00 +0000
+banner: 2018_11_19_panel.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/443626016165293/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+A few special guests from the games industry are coming in for a Q&A panel on the games industry - prepare your questions now! (It’s right before the gamejam so please do come!)

--- a/_events/2018_11_21_omg.md
+++ b/_events/2018_11_21_omg.md
@@ -1,0 +1,17 @@
+---
+layout: event
+published: true
+title: CSS takes on OMG!
+date:     2018-11-21 20:00:00 +0000
+date_end: 2018-11-22 04:00:00 +0000
+banner: 2018_11_21_omg.jpg
+location: OMG
+fb_link: https://www.facebook.com/events/267114723999415/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Hey all! For our next social we will start at the White Harte for some fun and games. And then head to OMG for a fabulous night of great music! 🎵🎵

--- a/_events/2018_11_22_lounge.md
+++ b/_events/2018_11_22_lounge.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: Code Lounge | Explore Week
+date:     2018-11-22 13:00:00 +0000
+date_end: 2018-11-22 15:00:00 +0000
+banner: 2018_11_22_lounge.jpg
+location: MVB Lower Atrium
+fb_link: https://www.facebook.com/events/730589293972181/
+ticket_link: https://goo.gl/forms/uABedTlCQ4RTjuVy2
+price: Free
+category:
+    - Networking
+cohost:
+---
+
+
+Confounded with currying? Confused by cryptography? In a crisis with classes? Cursed by contradiction? Cussing out calloc?
+
+Come to CodeLounge, our communal coursework help and mentoring session. We encourage all freshers to come (undergraduate and masters!) - but everyone is welcome.
+
+/// (2nd year+) SIGN UP AS A HELPER ///
+https://goo.gl/forms/uABedTlCQ4RTjuVy2
+
+And if that isn't enough - there'll be free food.

--- a/_events/2018_11_23_lightning.md
+++ b/_events/2018_11_23_lightning.md
@@ -1,0 +1,20 @@
+---
+layout: event
+published: true
+title: Lightning Talks | Explore Week
+date:     2018-11-23 13:00:00 +0000
+date_end: 2018-11-23 14:00:00 +0000
+banner: 2018_11_23_lightning.jpg
+location: MVB 1.11/1.11A
+fb_link: https://www.facebook.com/events/348782899208946/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+/// INTERESTED IN GIVING A TALK? ///
+https://goo.gl/forms/JS3DiqMcTOfl4I7k1
+
+Our very own students & researchers will be giving ~20min short talks.

--- a/_events/2018_11_27_cookpad.md
+++ b/_events/2018_11_27_cookpad.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: A Journey Through Recipies and Embeddings | Cookpad
+date:     2018-11-27 13:00:00 +0000
+date_end: 2018-11-27 14:00:00 +0000
+banner: 2018_11_27_cookpad.jpg
+location: Queens 1.15
+fb_link: https://www.facebook.com/events/747313148952198/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: cookpad
+---
+
+Gianandrea Minneci is coming down from Cookpad, one of our local sponsors, to give a talk on Machine Learning!
+
+Free food as always - see the poll in discussion for any specific dietary requirements.
+----
+TALK DESCRIPTION:
+Cookpad's Head of Machine Learning will introduce some practical applications of ML we're researching and applying to fulfil our mission to make everyday cooking fun.. A few of the ML team will also join the event and will be happy to answer questions.
+SPEAKER:
+Gianandrea Minneci

--- a/_events/2018_12_04_bt_ctf.md
+++ b/_events/2018_12_04_bt_ctf.md
@@ -1,0 +1,34 @@
+---
+layout: event
+published: true
+title: BT CTF
+date:     2018-12-04 18:00:00 +0000
+date_end: 2018-12-04 20:30:00 +0000
+banner: 2018_12_04_bt_ctf.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/264563627458674/
+ticket_link:
+price: Free
+category:
+  - Competition
+cohost:
+  - company: BT
+---
+
+BT Security are running a Capture the Flag (CTF) event on Tuesday 4th December 2018. This challenge will test your knowledge of ciphers, encryption, reverse-engineering, web exploits and much more. All levels of ability and experience are welcome as there will be tricky challenges to engage beginners and experts alike. You may find it helpful to use the internet to solve these challenges.
+
+This event is being held in MVB 1.11 and registration will start at 6:00pm, with the event starting promptly at 6:30pm. It will run for approximately 2 hours, with a pizza break in the middle!
+
+This event will be run by 3 Bristol alumni who are currently on the graduate scheme. There will be plenty of opportunities to speak to us about our exciting summer student and graduate programmes.
+
+This challenge should be completed in teams of sizes 2-3. If you don’t have a team yet then no need to worry, we will easily be able to slot you into a team on the day.
+
+You will all need to bring a laptop so that you can connect to the CTF webpage.
+
+Looking forward to seeing you all!
+
+---
+
+As always, there will be food 🍕 - make sure to hit 'going' on the FB event, and answer—or comment on—the poll in the discussion if you have dietary requirements!
+
+Thanks to BT for sponsoring this event.

--- a/_events/2018_12_14_ice_skating.md
+++ b/_events/2018_12_14_ice_skating.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: CSS on Ice!
+date:     2018-12-14 20:00:00 +0000
+date_end: 2018-12-14 23:59:00 +0000
+banner: 2018_12_14_ice_skating.jpg
+location: We The Curious
+fb_link: https://www.facebook.com/events/385417018865505/
+ticket_link: https://www.wethecurious.org/buy-tickets?event=10
+price: £10
+category:
+    - Social
+---
+
+No better way to get into the Christmas spirit than with some ice skating!  🎅⛸⛸⛸🎄🎁
+We are heading down to the ice rink this Friday for an ice skating session. And then having some drinks at The Apple afterwards, perhaps some mulled wine to warm you up?
+
+First round's on us!
+
+Be sure to get the 8:00pm - 8:45pm Disco Boots session on Friday the 14th.
+Tickets: https://www.wethecurious.org/buy-tickets?event=10
+
+Hope to see you there! :)
+

--- a/_events/2018_12_18_mvball.md
+++ b/_events/2018_12_18_mvball.md
@@ -1,0 +1,27 @@
+---
+layout: event
+published: true
+title: MVBall
+date:     2018-12-18 19:00:00 +0000
+date_end: 2018-12-18 23:00:00 +0000
+banner: 2018_12_18_mvball.jpg
+location: Mercure Bristol Grand Hotel
+fb_link: https://www.facebook.com/events/262213717821193/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+  - company: BEEES
+---
+
+CSS and BEEES are excited to announce our second MVBall!
+
+Fancy a night of wine, fine dining, getting smashed in suits and hammered in heels?
+Click GOING to receive updates!
+
+Your ticket will include a welcome drink on arrival, a three course meal and half a bottle of wine.
+There will also be a DJ providing banging tunes and a photographer at the venue to capture the moment 😊
+
+Dress Code: Black tie
+Location: Mercure Grand Hotel

--- a/_events/2018_12_18_mvball_after.md
+++ b/_events/2018_12_18_mvball_after.md
@@ -1,0 +1,29 @@
+---
+layout: event
+published: true
+title: MVBall Official After Party
+date:     2018-12-18 23:00:00 +0000
+date_end: 2018-12-19 04:00:00 +0000
+banner: 2018_12_18_mvball_after.jpg
+location: Lola Lo
+fb_link: https://www.facebook.com/events/1176762445816223/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+  - company: BEEES
+---
+
+Wristbands for discounted entry will be given out at MVBall!
+FREE DRINKS at Lola Lo*
+VIP areas
+
+Come straight from MVBall to keep the party going or stop off at the Berkley on the way
+
+More info soon, any burning questions please contact
+Kira Goode, Social Sec BEEES social-secretary@beees.co.uk
+or CSS https://cssbristol.co.uk/contact/
+
+
+*Free bottle of drink for every ten people that come

--- a/_events/2018_12_20_pub_quiz.md
+++ b/_events/2018_12_20_pub_quiz.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+title: CSS Christmas Pub Quiz
+date:     2018-12-20 18:30:00 +0000
+date_end: 2018-12-20 21:30:00 +0000
+banner: 2018_12_20_pub_quiz.jpg
+location: The White Rabbit
+fb_link: https://www.facebook.com/events/1962335013885008/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Hosted by the legendary Quizmaster ✨HAKEEM KUSHORO✨, you will be tested on a variety of knowledge ranging from fast Fourier transforms to Britney Spears.
+
+Rules:
+* Groups of MAX 5
+* 💰£10💰 each for the winners
+* 😮FREE😮 entry
+
+See you at The White Rabbit 🐇! (why not get a pizza while you're there?)

--- a/_events/2018_12_22_minecraft.md
+++ b/_events/2018_12_22_minecraft.md
@@ -1,0 +1,34 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS plays Minecraft
+date:     2018-12-22 13:00:00 +0000
+date_end: 2019-02-01 14:00:00 +0000
+banner: 2018_12_22_minecraft.png
+location:
+fb_link:
+ticket_link: https://forms.office.com/Pages/ResponsePage.aspx?id=MH_ksn3NTkql2rGM8aQVGxsrbThU-mNCqM0m5H2UA4hURExVMFhTNVpCT0c2RjFZVkNIQUxBUUxFUi4u
+price: Free
+category:
+    - Social
+cohost:
+---
+
+## Connecting
+
+* **ip**: `132.145.54.223`
+  * this might change - it'll be `minecraft.cssbristol.co.uk` eventually
+* **whitelist**: apply [here](https://forms.office.com/Pages/ResponsePage.aspx?id=MH_ksn3NTkql2rGM8aQVGxsrbThU-mNCqM0m5H2UA4hURExVMFhTNVpCT0c2RjFZVkNIQUxBUUxFUi4u)
+
+## Rules
+
+These rules are up to the discretion of the moderators. Offenses will be dealt with on a case-by-case basis. If you get banned you can appeal by emailing `webmaster@cssbristol.co.uk`.
+
+1. **don't be a dick**
+2. no hate speech, harassment, bullying, or spam
+3. no inappropriate constructions or skins
+4. no griefing/random killing of other players
+5. no use of hacks
+6. respect personal space

--- a/_events/2019_01_25_end_exam_drinks.md
+++ b/_events/2019_01_25_end_exam_drinks.md
@@ -1,0 +1,17 @@
+---
+layout: event
+published: true
+title: End of exam drinks
+date:     2019-01-25 18:00:00 +0000
+date_end: 2019-01-25 23:00:00 +0000
+banner: 2019_01_25_end_exam_drinks.jpg
+location: The White Harte
+fb_link: https://www.facebook.com/events/229382884604224/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Exams are over - time to celebrate!
+Join us at the White Harte at 6pm for drinks, board games, and a chat. 🍻

--- a/_events/2019_02_07_dyson.md
+++ b/_events/2019_02_07_dyson.md
@@ -1,0 +1,20 @@
+---
+layout: event
+published: true
+title: Dyson's Experts Present
+date:     2019-02-07 13:00:00 +0000
+date_end: 2019-02-07 14:00:00 +0000
+banner: 2019_02_07_dyson.jpg
+location: Pugsley
+fb_link: https://www.facebook.com/events/430062510865528/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: Dyson
+---
+
+CSS presents a series of three short talks from some of Dyson's software experts. They'll be discussing Elliptic Curve Cryptography (and why it's better than RSA), a whistle-stop tour of the landscape of Machine Learning and an intro to Image Processing techniques and challenges for robotic navigation.
+
+Please click Going if you will be attending, and answer the poll if you have dietary requirements. *If you do not answer the poll, accommodations can not be made and you will not get free food 😢*

--- a/_events/2019_02_16_bae_ctf.md
+++ b/_events/2019_02_16_bae_ctf.md
@@ -1,0 +1,30 @@
+---
+layout: event
+published: true
+title: BAE Systems CTF 2019
+date:     2019-02-16 09:00:00 +0000
+date_end: 2019-02-16 16:30:00 +0000
+banner: 2019_02_16_bae_ctf.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/2285258968180584/
+ticket_link: mailto:ctf@baesystems.com
+price: Free
+category:
+  - Competition
+cohost:
+  - company: BAE Systems Applied Intelligence
+---
+
+BAE Systems Applied Intelligence are running a Capture the Flag event, a day of cyber security challenges and games, on Saturday 16th February 2019. Anybody who is currently enrolled at Bristol University can sign up and play. There are prizes for the winning team and goodies for anyone taking part!
+
+The competition is being held in MVB 1.11/1.11a and will start at 09:30 and finish at 16:00, with lunch provided by us. We’ll be around all day to provide hints and tips on the challenges and are happy to discuss careers in cyber security and software engineering in BAE Systems Applied Intelligence. If you’re interested please send us an email and sign up!
+
+This is a team-based challenge for teams of 2 to 6 players. If you don’t have a team yet then don’t worry – come along anyway as teams will be created on the day. The challenges will involve breaking into vulnerable websites, cracking ciphers, forensic searches, reverse engineering and much more. No previous experience of these kinds of challenge is necessary; they are designed for students who like taking things apart and seeing how they work.
+
+To sign up, please email ctf@baesystems.com from your university email account with the following information:
+· Your full name
+· Your team name (if applicable)
+· Your year of study
+· Your course title
+
+If you are signing up on behalf of others, please include the above information for them too. The deadline for signing up is Wednesday 13th February. We will email you to confirm your place and provide more details on the event and what you need to bring. We really hope to see you there.

--- a/_events/2019_02_21_white_tshirt.md
+++ b/_events/2019_02_21_white_tshirt.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: White T-Shirt Social
+date:     2019-02-21 20:00:00 +0000
+date_end: 2019-02-22 04:00:00 +0000
+banner: 2019_02_21_white_tshirt.jpg
+location: The Berkeley Wetherspoons
+fb_link: https://www.facebook.com/events/258711685004367/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Hello everyone! It's time for our next social and it's gonna fun one!
+We'll be meeting up at Berkerley for a white T-shirt social. 🥋🥋🎉
+
+Bring a white t-shirt you don't mind getting written on and a marker if you have one. You'll then have to cover peoples t-shirts with anything creative you can come up with. Show some love or throw shade it's up to you :)
+
+Then we'll head to liveliest club on the triangle to show off our fancy new clothing 💃💃

--- a/_events/2019_02_28_hash_code.md
+++ b/_events/2019_02_28_hash_code.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+title: Google Hash Code 2019
+date:     2019-02-28 17:00:00 +0000
+date_end: 2019-02-28 21:30:00 +0000
+banner: 2019_02_28_hash_code.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/1248025058694178/
+ticket_link: https://g.co/hashcode
+price: Free
+category:
+    - Competition
+cohost:
+  - company: Google
+---
+
+IMPORTANT: This event requires registration ahead of time! Please come promptly at 5pm if you do not have a team as these need to be submitted to the Judge System before 5:30pm on the day!
+
+---
+
+Join us to take part in Google Hash code, a team programming challenge hosted by Google.
+
+The qualification round is on Thursday 28th February from 17:00 and the top teams from the qualification round will be invited to take part in the second round in on of Google's international offices with a chance to win a cash prize.
+
+Get a team of 2-4 people together and sign up at https://g.co/hashcode
+
+Remember to bring your own laptop

--- a/_events/2019_03_05_code_lounge.md
+++ b/_events/2019_03_05_code_lounge.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+title: CodeLounge II | Explore Week
+date:     2019-03-05 13:00:00 +0000
+date_end: 2019-03-05 15:00:00 +0000
+banner: 2019_03_05_code_lounge.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/2276160976041451/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Confounded with currying? Confused by cryptography? In a crisis with classes? Cursed by contradiction? Cussing out calloc?
+
+Come to CodeLounge, our communal coursework help and mentoring session. We encourage all freshers to come (undergraduate and masters!) - but everyone is welcome.
+
+/// (2nd year+) SIGN UP AS A HELPER ///
+https://goo.gl/forms/uABedTlCQ4RTjuVy2
+
+And if that isn't enough - there'll be free food.

--- a/_events/2019_03_06_curriculum_inp.md
+++ b/_events/2019_03_06_curriculum_inp.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: CS Curriculum Input Session
+date:     2019-03-06 11:00:00 +0000
+date_end: 2019-03-06 13:00:00 +0000
+banner: 2019_03_06_curriculum_inp.jpg
+location: Queens Building 1.7
+fb_link: https://www.facebook.com/events/392125768266882/
+ticket_link:
+price: Free
+category:
+    - Networking
+---
+
+The CS department is exploring how they can make useful changes to the CS curriculum - they want to get student input.
+
+Two Curriculum Input sessions have been arranged during Explore Week:
+- Session 1 for 1st and 2nd Years: Weds 6th March, 11am-12 noon, Queens Building 1.7
+- Session 2 for 3rd and 4th Years: Weds 6th March, noon-1pm, Queens Building 1.7
+
+Come along to one of these sessions in order to:
+- Let the dept. know what you like and don’t like about the current curriculum
+- Find out what the department’s current thinking is regarding updating the curriculum
+- Let the dept. know your opinions and ideas about the changes that we’re considering

--- a/_events/2019_03_06_hardware_hacking.md
+++ b/_events/2019_03_06_hardware_hacking.md
@@ -1,0 +1,17 @@
+---
+layout: event
+published: true
+title: An Introduction to Hardware Hacking
+date:     2019-03-06 17:00:00 +0000
+date_end: 2019-03-06 18:00:00 +0000
+banner: 2019_03_06_hardware_hacking.jpg
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/639658169798959/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+In this talk/discussion we will go over what hardware hacking is all about. We'll discuss what tools and resources are available to us to have a go at hardware hacking for ourselves. Finally, we'll go through a few examples of hardware "Hacks" and how they work.
+This talk won't be about finding security exploits in computer hardware, It will be more focused creative rather than destructive goals.

--- a/_events/2019_03_07_data_science.md
+++ b/_events/2019_03_07_data_science.md
@@ -1,0 +1,84 @@
+---
+layout: event
+published: true
+title: Meet Industry in CS & Data science | Explore week
+date:     2019-03-07 13:00:00 +0000
+date_end: 2019-03-07 16:00:00 +0000
+banner: 2019_03_07_data_science.jpg
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/552628041906532/
+ticket_link:
+price: Free
+category:
+    - Networking
+---
+
+The department has recently established two External Advisory Boards (EAB) for Computer Science and Data Science. These are full of staff from industry/government/more who will help the department consider their teaching, research, and engagement with applied CS/Data Science.
+
+CSS is working with the department to invite 2nd/3rd/4th to meet with members of the board. This is a great opportunity for students to ask questions about future careers, network, and give board members an idea of what it's like to study here.
+
+There are two sessions on Thursday 07/03/19 - you can attend both if you want to:
+
+* Data Science Industry Q&A -  1-2pm:
+https://careers.bristol.ac.uk/students/events/detail/454772
+* Computer Science Q&A - 3-4pm:
+https://careers.bristol.ac.uk/admin/events/info/454771/dashboard
+
+Board members include Directors, CEOs and more from Intel, Microsoft, Amazon, Ultrahaptics, and more.
+
+---
+Full list:
+Computer Science advisory board:
+Adrian Tate, Cray, Director, https://www.linkedin.com/in/atate/
+
+Ben Sach, Alan Turing Institute, Data Scientist, https://www.linkedin.com/in/bgsach/
+
+Carolyn Hassan, Knowle West Media Centre, Director, https://www.linkedin.com/in/carolyn-hassan-984b5b5/
+
+Emily Hill, Ghyston, CEO and Co-Founder, https://www.linkedin.com/in/emily-hill-0277a1a2/
+
+Gemma Coles, Mubaloo, Managing Partner, https://www.linkedin.com/in/gemma-coles-227a6510/
+
+Jenny Griffiths, SnapFashion, Founder, https://www.linkedin.com/in/jennygriffiths/
+
+Jim Cownie, Intel, Snr Principal Engineer, https://uk.linkedin.com/in/jim-cownie-3939b1
+
+Jo Reid, Calvium, Managing Director, https://www.linkedin.com/in/reidjo/
+
+Kenton O'Hara, Microsoft Research, Senior Scientist, https://www.linkedin.com/in/kenton-o-hara-9021a31/
+
+Matt Ball, Thales, Chief Scientist, https://www.linkedin.com/in/matt-ball-a970b17/
+
+Mike Bartley, Test & Verification Solutions, Founder and CEO, https://www.linkedin.com/in/drmikebartley/
+
+Monika Radclyffe, SET Squared, Director, https://www.linkedin.com/in/monika-radclyffe/
+
+Serrie Chapman, Women’s Tech Jobs, Founder, https://www.linkedin.com/in/serrie-chapman-55a5927/
+
+Tom Carter, Ultrahaptics, Founder, https://www.linkedin.com/in/tom-carter/
+
+Yoge Patel, Blue Bear Systems, CEO, https://www.linkedin.com/in/dr-yoge-patel-5ba57917/
+
+--------------------------------
+
+Amelia Waddington, LiveRamp, Director of Product, https://www.linkedin.com/in/amelia-waddington-26742a9/
+
+Angela Watkins, Welsh Assembly, Senior Science Officer, https://www.linkedin.com/in/angela-watkins-63961123/
+
+Chew Yean Yam, Microsoft, Principal Data Scientist, https://www.linkedin.com/in/cyyam/
+
+Christa Mpundu, Goldman Sachs, Associate, https://www.linkedin.com/in/mcmpundu/
+
+Elisabeth Olafsdottir, Cognizant, Director AI and Analytics, https://www.linkedin.com/in/elisabeth-olafsdottir/
+
+Emma-Claire Shaw, DEFRA, Innovation Consultant, https://www.linkedin.com/in/emmaclairepengelly/
+
+Gjeta Gjyshinca, Morgan Stanley, Application Developer, https://www.linkedin.com/in/gjetagjyshinca/
+
+Paul Selwood, Met Office, Science Fellow, https://www.metoffice.gov.uk/research/people/paul-selwood
+
+Sole Galli, LV, Lead Data Scientist, https://www.linkedin.com/in/soledad-galli-09260271/
+
+Tom Diethe, Amazon, Applied Science Manager, https://www.linkedin.com/in/tomdiethe/
+
+Tom Smith, Office of National Stats, Chief Data Scientist, https://www.linkedin.com/in/tomdatasmith/

--- a/_events/2019_03_07_pub_quiz.md
+++ b/_events/2019_03_07_pub_quiz.md
@@ -1,0 +1,24 @@
+---
+layout: event
+published: true
+title: Pub Quiz with TPP | Explore Week
+date:     2019-03-07 19:00:00 +0000
+date_end: 2019-03-07 22:00:00 +0000
+banner: 2019_03_07_pub_quiz.jpg
+location: Racks Bar & Kitchen
+fb_link: https://www.facebook.com/events/635255983578919/
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/pub-quiz-with-tpp-e89c
+price: Free
+category:
+    - Social
+---
+
+Join us at Racks Bar & Kitchen for a Pub Quiz like no other!
+
+Make sure you bring a laptop and get ready to exercise your problem solving skills in a series of fun coding challenges!
+
+FREE FOOD & DRINK
+
+PRIZES for the winning teams (Raspberry Pis and a Hotel Chocolat Hamper)
+
+We recommend teams of about 5-6 people, but smaller groups are welcome too, and if you’re unsure who to come with then we’ll be happy to match you up with other keen problem solvers on the day.

--- a/_events/2019_03_08_hackathon.md
+++ b/_events/2019_03_08_hackathon.md
@@ -1,0 +1,42 @@
+---
+layout: event
+published: true
+title: CSSxBoeing Hackathon 2019
+date:     2019-03-08 13:00:00 +0000
+date_end: 2019-03-08 15:00:00 +0000
+banner: 2019_03_08_hackathon.jpg
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/561163404398450/
+ticket_link: http://bit.ly/csshack19-signup
+price: Free
+category:
+  - Competition
+cohost:
+  - company: Boeing
+---
+
+The CSSxBoeing Hackathon is back!
+
+// SIGNUP //
+
+http://bit.ly/csshack19-signup
+
+- Teams of up to 6 people
+- Not got anyone to work with or a full team? No worries. Just indicate that you'd like to be matched with others and we'll sort out the rest
+
+// RULES/HEALTH & SAFETY //
+http://bit.ly/csshack19-rules
+
+// THEME //
+Our theme this year is Wellbeing & Safety ❤️🏃🏽‍♀️
+
+The prizes will be awarded in three categories:
+
+Mental Health
+- Experiment with ways to supplement mental health issues.
+
+Fitness
+- Use various APIs (such as Google Fit’s) or build a physical peripheral to help with fitness.
+
+Safety
+- Create something to promote and aid health & safety.

--- a/_events/2019_03_12_ian_drinks.md
+++ b/_events/2019_03_12_ian_drinks.md
@@ -1,0 +1,31 @@
+---
+layout: event
+published: true
+title: Dr Ian's Leaving Drinks | CSS Bar Crawl 2
+date:     2019-03-12 20:00:00 +0000
+date_end: 2019-03-13 04:00:00 +0000
+banner: 2019_03_12_ian_drinks.jpg
+location: Alterego
+fb_link: https://www.facebook.com/events/547974575700291/
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/css-bar-crawl-2-dr-ian-s-leaving-drinks
+price: $PRICE
+category:
+    - Social
+---
+
+TICKETS BOUGHT PAST 6th MARCH WILL INCLUDE ENTRY TO THE CLUB AND A T-SHIRT, BUT THE T-SHIRT WILL NOT BE AVAILABLE ON THE DAY
+
+------------------
+
+Join use to celebrate our much loved Dr Ian Holyer's leaving drinks after an impressive career at the University of Bristol.
+
+👕🎽 GET YOUR *EXCLUSIVE* DR IAN THEMED T-SHIRT NOW 👚👔
+https://www.bristolsu.org.uk/groups/computer-science-society/events/css-bar-crawl-2-dr-ian-s-leaving-drinks
+
+DEADLINE: MARCH 6TH 10PM
+
+ROUTE:
+8:00pm - Alterego
+9:00pm - WG Grace
+10:00pm - Mbargo
+10:45pm - Lola Lo

--- a/_events/2019_03_14_flowers.md
+++ b/_events/2019_03_14_flowers.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: Stop and Smell the Flowers - Augmenting VR with Olfaction
+date:     2019-03-14 13:00:00 +0000
+date_end: 2019-03-14 14:00:00 +0000
+banner: 2019_03_14_flowers.jpg
+location: Pugsley
+fb_link: https://www.facebook.com/events/2181851568524548/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+Dr. Jon Bird Has offered to give a talk on his research into creating smell for VR.  Come along to this talk to find out how he did this and his results.
+
+Free food as always - see the poll in the discussion for any specific dietary requirements.
+# TALK DESCRIPTION:
+Affordable virtual reality (VR) technology is now widely available and there is increasing interest in whether using sensory modalities in addition to vision and sound can enhance VR experiences. Smell has a strong influence on how we experience the world, for example, odours can modulate moods, trigger memories and affect alertness. Recent studies have found some evidence that odours can enhance the sense of presence in VR, but research in this area is still exploratory.
+
+In this talk I’ll describe a number of studies we’ve carried out where we have augmented VR with olfaction using a novel odour selection methodology and a cheap olfactory display made from off-the-shelf components. We demonstrate that congruent pleasant odours enhance presence in a VR game, whereas incongruent pleasant odours do not. However, both types of odour can improve user performance.
+
+## SPEAKER:
+Jon Bird is a Senior Lecturer in Digital Health at the University of Bristol. His main research focus is on developing mobile technologies for a range of health domains, including verbal autopsy and tracking the health and wellbeing of people living with HIV. He also develops wearable technologies using haptics and more unusual sensory modalities such as temperature and smell.

--- a/_events/2019_03_29_what_unit.md
+++ b/_events/2019_03_29_what_unit.md
@@ -1,0 +1,19 @@
+---
+layout: event
+published: true
+title: CS Unit Choices Exhibition
+date:     2019-03-29 13:00:00 +0000
+date_end: 2019-03-29 14:00:00 +0000
+banner: 2019_03_29_what_unit.png
+location: MVB 1.11A
+fb_link: https://www.facebook.com/events/2274398252886953/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+📍 WHERE: MVB 1.11A
+🕐 WHEN: 13:00-13:50
+---
+Come along for a Q&A on what students think about optional units in 2/3/4th year.

--- a/_events/2019_04_03_css_minihack.md
+++ b/_events/2019_04_03_css_minihack.md
@@ -1,0 +1,18 @@
+---
+layout: event
+published: true
+title: CSSxAI Gaming Minihack
+date:     2019-04-03 17:30:00 +0100
+date_end: 2019-04-03 21:40:00 +0100
+banner: 2019_04_03_css_minihack.jpg
+location: MVB
+fb_link: https://www.facebook.com/events/280600549508146/
+ticket_link:
+price: Free
+category:
+  - Competition
+cohost:
+  - company: AI Gaming
+---
+
+Join us and the lovely guys from AIGaming and create an AI for a game which will be revealed on the day! All levels of experience with Python welcome! Free pizza, cookies and redbull included, and prizes for the winners of the tournament!

--- a/_events/2019_05_03_agm.md
+++ b/_events/2019_05_03_agm.md
@@ -1,0 +1,103 @@
+---
+layout: event
+published: true
+title: CSS AGM 2019
+date:     2019-05-03 17:00:00 +0100
+date_end: 2019-05-03 20:00:00 +0100
+banner: 2019_05_03_agm.png
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/614112879103391/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+# CSS AGM 2019
+
+<!-- <div class="agm-timer">
+    <div class="agm-timer-title" width="300px">Submissions end May 1st, midnight</div>
+    <div class="agm-timer-cont">
+        <span id="agm__time-days"></span>
+        <span id="agm__time-hours"></span>
+        <span id="agm__time-mins"></span>
+        <span id="agm__time-secs"></span>
+    </div>
+</div> -->
+
+## VOTING LINKS:
+- [PRESIDENT](https://bit.ly/css-agm19-pres)
+- [VICE PRESIDENT](https://bit.ly/css-agm19-vicepres)
+- [SECRETARY](https://bit.ly/css-agm19-sec)
+- [TREASURER](https://bit.ly/css-agm19-treas)
+- [EVENTS OFFICER](https://bit.ly/css-agm19-events)
+- [PRESS OFFICER](https://bit.ly/css-agm19-press)
+- [WEBMASTER](https://bit.ly/css-agm19-web)
+- [SPORTS & SOCIAL OFFICER](https://bit.ly/css-agm19-sport)
+- [OUTREACH OFFICER](https://bit.ly/css-agm19-outreach)
+- [EQUALITY & DIVERSITY OFFICER](https://bit.ly/css-agm19-eqd)
+- [GENERAL OFFICER #1](https://bit.ly/css-agm19-gen1)
+- [GENERAL OFFICER #2](https://bit.ly/css-agm19-gen2)
+- [MOTION 1](https://bit.ly/css-agm19-mot1)
+- [MOTION 2](https://bit.ly/css-agm19-mot2)
+
+CSS' AGM is upon us once again! Join us in <b>MVB 1.11(A) at 17:00, Friday 3rd May</b> to vote on motions and committee nominees.
+
+If you're abroad this year or can't attend the AGM - don't worry! You can still nominate yourself/submit a motion. We recommend recording a short video of yourself speaking so that we can play it at the AGM. If you like, we can read out a written statement instead.
+
+(Nominations for First-Year Rep and Post-Grad Rep will be occur after the start of the next university year)
+
+Free pizza 🍕, falafel 🧆, and cider/beer 🍺 as per usual x
+
+<script>
+    const end = new Date("May 02, 2019 00:00:00").getTime();
+    // thank you https://www.developerdrive.com/2019/02/build-countdown-timer-pure-javascript/
+
+    var timer = setInterval(() => {
+        let now = new Date().getTime();
+        let t = end - now;
+
+        let days = Math.floor(t / (1000 * 60 * 60 * 24));
+        let hours = Math.floor((t % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+        let mins = Math.floor((t % (1000 * 60 * 60)) / (1000 * 60));
+        let secs = Math.floor((t % (1000 * 60)) / 1000);
+
+        document.getElementById('agm__time-days').innerHTML = days + 'd';
+        document.getElementById('agm__time-hours').innerHTML = hours + 'h';
+        document.getElementById('agm__time-mins').innerHTML = mins + 'm';
+        document.getElementById('agm__time-secs').innerHTML = secs + 's';
+    }, 1000);
+</script>
+
+---
+## Roles
+
+<a class="btn btn--dark" href="http://bit.ly/css-agm19-roles">
+    Nominate yourself for a role!
+</a>
+
+Could you see yourself at the helm of our next Hackathon or Bar Crawl? Being a committee member is a great way to gain experience running events, dealing with industrial sponsors and communications. And to boot - it's a whole lot of fun!
+
+You will have a chance to speak for 60s (once, regardless of how many positions you apply for) during the AGM.
+
+Here's a taste of what each role does:
+
+{% for role in site.data.roles18-19 %}
+### {{ role.role }}
+<ul>
+    {% for point in role.desc %}
+        <li>{{ point }}</li>
+    {% endfor %}
+</ul>
+{% endfor %}
+
+---
+## Motions
+
+<a class="btn btn--dark" href="http://bit.ly/css-agm19-motions">
+    Submit a motion!
+</a>
+
+Want to make a change to how the society runs? Put forward a motion to change our constitution (https://cssbristol.co.uk/constitution).
+
+Constitutional changes must receive a two-thirds majority. Non-constitutional motions must receive a majority.

--- a/_events/2019_06_09_BBQ_banner.md
+++ b/_events/2019_06_09_BBQ_banner.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+title: BarbeqWU
+date:     2019-06-09 13:00:00 +0100
+date_end: 2019-06-09 18:00:00 +0100
+banner: 2019_06_09_BBQ_banner.jpg
+location: Brandon Hill
+fb_link: https://www.facebook.com/events/340749229917396/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+Join us for a post-exam barbeqWU!
+Free food, alcohol, and games!
+Where: Brandon hill
+When: Sunday 9th June 13:00
+
+Will Nick be there?
+> Maybe Yes
+
+If you have any dietary requirements please let us know in the poll!

--- a/_events/2019_09_24_welcome_drinks.md
+++ b/_events/2019_09_24_welcome_drinks.md
@@ -1,0 +1,19 @@
+---
+layout: event
+published: true
+title: Freshers Welcome Drinks
+date:   2019-09-24 19:00:00 +0100
+date_end:   2019-09-24 23:00:00 +0100
+banner: 2019_09_24_welcome_drinks.png
+location: The White Harte
+fb_link: https://www.facebook.com/events/368092517145447/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+Join us at 7pm for drinks (and food if you are feeling hungry)!
+
+Make new friends and meet the CSS committee.  Take a break from the madness of Freshers Week.
+
+Every one is welcome and don't worry; you don't have to drink anything if you don't want to.

--- a/_events/2019_09_26_family_meet_up.md
+++ b/_events/2019_09_26_family_meet_up.md
@@ -1,0 +1,20 @@
+---
+layout: event
+published: true
+title: Family Meet Up
+date:   2019-09-26 13:00:00 +0100
+date_end:   2019-09-26 17:00:00 +0100
+banner: 2019_09_26_family_meet_up.png
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/562932227446724/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Freshers come and meet your CS family, play some games, and maybe even go for a drink!
+
+You'll find out who your parents and siblings are on the day!
+
+Sign up to be a parent: https://forms.gle/pPFvHutA97stypEP9

--- a/_events/2019_10_09_css_does_board_games.md
+++ b/_events/2019_10_09_css_does_board_games.md
@@ -1,0 +1,15 @@
+---
+layout: event
+published: true
+title: Board games night
+date:     2019-10-09 14:00:00 +0100
+date_end: 2019-10-09 17:00:00 +0100
+banner: 2019_10_09_css_does_board_games.png
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/430663744225485/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+Join us for a fun filled evening with board games! Bring your CS family!

--- a/_events/2019_10_09_git_talk.md
+++ b/_events/2019_10_09_git_talk.md
@@ -1,0 +1,18 @@
+---
+layout: event
+published: true
+title: GIT GUD with David
+date:     2019-10-09 13:00:00 +0100
+date_end: 2019-10-09 14:00:00 +0100
+banner: 2019_10_09_git_talk.png
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/547931105961163/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+Git is an extremely powerful version control tool which helps you work on large scale programming projects as a group or an individual.
+That's why we've got our very own David Bernhard to show you the ropes and guide you on your path to becoming a Git Wizard.
+Yes, freshers, you will be needing git throughout your university career and in industry so better start learning it now 😉

--- a/_events/2019_10_14_safe_leaving_drinks.md
+++ b/_events/2019_10_14_safe_leaving_drinks.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: SAFE Leaving Drinks
+date:     2019-10-14 19:00:00 +0100
+date_end: 2019-10-14 21:00:00 +0100
+banner: 2019_10_14_safe_leaving_drinks.jpg
+location: The White Bear
+fb_link: https://www.facebook.com/events/638875413185405/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+SAFE is going off tonight :'(

--- a/_events/2019_10_19_BAE_CTF.md
+++ b/_events/2019_10_19_BAE_CTF.md
@@ -1,0 +1,40 @@
+---
+layout: event
+published: true
+title: BAE System AI CTF
+date:     2019-10-19 09:15:00 +0100
+date_end: 2019-10-19 16:30:00 +0100
+banner: 2019_10_19_BAE_CTF.png
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/2460784210666318/
+ticket_link: mailto:ctf@baesystems.com
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: BAE Systems Applied Intelligence
+---
+
+Tldr; you must email ctf@baesystems.com with your name, team name, year of study, course, and any dietary requirements to sign up
+
+BAE Systems Applied Intelligence are running a Capture the Flag event, a day of cyber security challenges and games, on Saturday 19th October. Anybody who is currently enrolled at Bristol University can sign up and play. There are prizes for the winning team and goodies for anyone taking part!
+
+The competition is being held in the MVB 1.11/1.11A and will start at 10:00 and finish at 16:00, with lunch provided by us. We’ll be around all day to provide hints and tips on the challenges and are happy to discuss careers in cyber security and software engineering in BAE Systems Applied Intelligence. If you’re interested please send us an email and sign up!
+
+This is a team-based challenge for teams of 2 to 6 players. If you don’t have a team yet then don’t worry – come along anyway as teams will be created on the day. The challenges will involve breaking into vulnerable websites, cracking ciphers, forensic searches, reverse engineering and much more. No previous experience of these kinds of challenge is necessary; they are designed for students who like taking things apart and seeing how they work.
+
+To sign up, please email ctf@baesystems.com from your university email account with the following information:
+
+·         Your full name
+
+·         Your team name (if applicable)
+
+·         Your year of study
+
+·         Your course title
+
+·         Dietary requirements (if appropriate)
+
+If you are signing up on behalf of others, please include the above information for them too. The deadline for signing up is Friday 11th October. We will email you to confirm your place and provide more details on the event and what you need to bring. We really hope to see you there.
+
+BAE Systems will collect and process information about you that may be subject to data protection laws. For more information about how we use and disclose your personal information, how we protect your information, our legal basis to use your information, your rights and who you can contact, please refer to the relevant sections of our Privacy note at www.baesystems.com/en/cybersecurity/privacy

--- a/_events/2019_10_24_teaching_CSS_does_careers.md
+++ b/_events/2019_10_24_teaching_CSS_does_careers.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: A Panel of Teaching
+date:     2019-10-24 13:00:00 +0100
+date_end: 2019-10-24 14:00:00 +0100
+banner: 2019_10_24_teaching_CSS_does_careers.png
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/855501068184921/
+ticket_link:
+price: Free
+category:
+    - Careers
+---
+
+Find out what a career in teaching is like with insights from David Bernhard, Sion Hannuna, Tilo Burghardt, and Carl Henrik Ek.

--- a/_events/2019_10_29_PhDs_CSS_does_careers.md
+++ b/_events/2019_10_29_PhDs_CSS_does_careers.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: A panel of PhDs
+date:     2019-10-29 13:00:00 +0100
+date_end: 2019-10-29 14:00:00 +0100
+banner: 2019_10_29_PhDs_CSS_does_careers.png
+location: 1.18 Queens
+fb_link: https://www.facebook.com/events/2288860421405405/
+ticket_link:
+price: Free
+category:
+    - Careers
+---
+
+Find out what it's like to do a PhD from current PhD students

--- a/_events/2019_10_30_morgan_stanly_inteview.md
+++ b/_events/2019_10_30_morgan_stanly_inteview.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: Morgan Stanley Interview Skills
+date:     2019-10-30 13:00:00 +0100
+date_end: 2019-10-30 16:00:00 +0100
+banner: 2019_10_30_morgan_stanly_inteview.png
+location: Queens 1.6
+fb_link: https://www.facebook.com/events/438323823467310/
+ticket_link: https://morganstanley.tal.net/vx/lang-en-GB/candidate/postings/5455
+price: Free
+category:
+    - Careers
+cohost:
+  - company: Morgan Stanley
+---
+Morgan Stanley believes capital has the power to create positive change. We help the world finance great ideas that move society forward, and we rely on technology to do it.
+
+If you’re passionate about solving problems, working as part of a team, and being exposed to a huge variety of cutting-edge technologies, join us.
+
+We’re running an interactive two-hour technical interview and assessment centre skills session to help you prepare for your application to Technology at Morgan Stanley. You’ll have the chance to work through practice questions and coding exercises, as well as a mock group exercise, with our technologists. We hope the session will give you an opportunity to prepare for upcoming interviews and an insight into Technology careers with us.

--- a/_events/2019_10_31_css_watches_a_movie.md
+++ b/_events/2019_10_31_css_watches_a_movie.md
@@ -1,0 +1,18 @@
+---
+layout: event
+published: true
+title: CSS Watches a Movie
+date:     2019-10-31 18:00:00 +0100
+date_end: 2019-10-31 21:30:00 +0100
+banner: 2019_10_31_movie.jpg
+location: Pugsley Queens
+fb_link: https://www.facebook.com/events/576136083127316/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Join us to watch a Halloween movie on Halloween 😱
+
+Free popcorn

--- a/_events/2019_11_01_Start_ups_CSS_does_careers.md
+++ b/_events/2019_11_01_Start_ups_CSS_does_careers.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: A panel of Start-ups
+date:     2019-11-01 13:00:00 +0000
+date_end: 2019-11-01 14:00:00 +0000
+banner: 2019_11_01_Start_ups_CSS_does_careers.png
+location: 1.68 Queens
+fb_link: https://www.facebook.com/events/645082489349962/
+ticket_link:
+price: Free
+category:
+    - Careers
+---
+
+A panel of Bristol based entrepreneurs, including Bristol graduates, will share their experiences in creating a start-up and/or working in the early stages of one.

--- a/_events/2019_11_02_css_cogs_lan.md
+++ b/_events/2019_11_02_css_cogs_lan.md
@@ -1,0 +1,18 @@
+---
+layout: event
+published: true
+title: CSSxCOGS Lan
+date:     2019-11-02 12:00:00 +0000
+date_end: 2019-11-03 12:00:00 +0000
+banner: 2019_11_02_css_cogs_lan.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/508047843080933/
+ticket_link:
+price: £5
+category:
+    - Social
+cohost:
+  - company: COGS
+---
+
+Come along to 1.11 in MVB for 24 hours of gaming with both COGS and the Computer Science Society! Everyone is encouraged to bring along their own setups, consoles and controllers. Entry is free for members or £5 for non-members (membership's only £3!). There'll be a pre-LAN meal beforehand on the Saturday as well and free Red Bull will be on offer throughout the LAN.

--- a/_events/2019_11_06_board_games.md
+++ b/_events/2019_11_06_board_games.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: Board Games night pt2
+banner: 2019_11_06_css_does_board_games.png
+date:     2019-11-06 14:00:00 +0000
+date_end: 2019-11-06 17:00:00 +0000
+location: MVB Lower ATrium
+fb_link: https://www.facebook.com/events/1236358449908084/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Join us for a night of fun with your favorite board games. Whether its risque responses to cards against humanity or exploding some kittens we've got them all in MVB.

--- a/_events/2019_11_12_Jump_trading_dist_systems.md
+++ b/_events/2019_11_12_Jump_trading_dist_systems.md
@@ -1,0 +1,24 @@
+---
+layout: event
+published: true
+title: Jump Trading's trading systems
+date:     2019-11-12 13:00:00 +0000
+date_end: 2019-11-12 14:00:00 +0000
+banner: 2019_11_12_Jump_trading_dist_systems.png
+location: 1.18 Queens
+fb_link: https://www.facebook.com/events/532026974021145/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: Jump Trading
+---
+
+A tech talk by Jump Trading, one of our new, lovely sponsors! They will talk about:
+- custom hardware
+- low latency software
+- distributed systems
+- high performance computing
+
+As always, there will be pizza!

--- a/_events/2019_11_15_November_2019_egm.md
+++ b/_events/2019_11_15_November_2019_egm.md
@@ -1,0 +1,28 @@
+---
+layout: event
+published: true
+title: 2019 EGM
+date:     2019-11-15 18:00:00 +0000
+date_end: 2019-11-15 20:00:00 +0000
+banner: 2019_11_15_November_2019_egm.png
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/332281607445580/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Join us for our October EGM where will elect our first year and post graduate rep!
+Free pizza, beer, and cider!
+
+Become the first year rep:
+https://forms.gle/D3GNtkNHRazA4cQAA
+
+Become the post graduate rep:
+https://forms.gle/9JrojjX3zcJFihje6
+
+Submit a motion:
+https://forms.gle/kgfdNu2a7jS4KNS46
+
+Entries close 14th November 20:00

--- a/_events/2019_11_20_bloomberg_cv.md
+++ b/_events/2019_11_20_bloomberg_cv.md
@@ -1,0 +1,24 @@
+---
+layout: event
+published: true
+title: Bloomberg interview and CV workshop
+date:     2019-11-20 13:00:00 +0000
+date_end: 2019-11-20 16:00:00 +0000
+banner: 2019_11_20_bloomberg_cv.jpg
+location: MVB 1.15
+fb_link: https://www.facebook.com/events/1452085498274712/
+ticket_link:
+price: Free
+category:
+    - Networking
+cohost:
+  - company: Bloomberg
+---
+
+Join us for an interview skills and CV workshop with Bloomberg!
+Please fill in this form if you are planning to attend the CSS workshop:
+http://bit.ly/2O8p0Ea
+
+Timetable:
+1.00-2.30pm - Session.
+2.30-3:00pm - Networking in MVB atrium area.

--- a/_events/2019_11_20_game_dev.md
+++ b/_events/2019_11_20_game_dev.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: Principles of Game design
+date:     2019-11-20 14:00:00 +0000
+date_end: 2019-11-20 15:00:00 +0000
+banner: 2019_11_20_game_dev.jpg
+location: Qeeuns 1.18
+fb_link: https://www.facebook.com/events/438008450246881/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+Come to our first talk to get you ready for the upcoming CSS Game Jam - or just enjoy an excellent presentation - of how game design works, its main principles and a number of applied examples from the game Minicraft - a game made by the creator of Minecraft for a 48 hr Game Jam!

--- a/_events/2019_11_21_how_game_jam.md
+++ b/_events/2019_11_21_how_game_jam.md
@@ -1,0 +1,17 @@
+---
+layout: event
+published: true
+title: How to Game Jam
+date:     2019-11-20 15:00:00 +0000
+date_end: 2019-11-20 16:00:00 +0000
+banner: 2019_11_21_how_game_jam.jpg
+location: MVB 2.11
+fb_link: https://www.facebook.com/events/1257528924436386/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+Prepare yourselves for the upcoming CSS Game Jam on the weekend!
+ Listen to some funny stories design failures, advice on planning, ideas and inspiration and some concrete examples, all from a veteran of game jamming - with over 19 game jams behind his back - 16 of which were 72 hours long!

--- a/_events/2019_11_22_Explore_week_game_jam.md
+++ b/_events/2019_11_22_Explore_week_game_jam.md
@@ -1,0 +1,27 @@
+---
+layout: event
+published: true
+title: Game Jam
+date:     2019-11-22 11:00:00 +0000
+date_end: 2019-11-23 15:00:00 +0000
+banner: 2019_11_22_Explore_week_game_jam.png
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/2201178300181313/
+ticket_link:
+price: Free
+category:
+    - Competition
+---
+
+Join us from Friday to Saturday to make the best (or worst) game you can. Please note that MVB will not be open for a continuous 24 hours. If you wish to stay on campus overnight we recommend the ASS library.
+Food and drinks provided.
+Prizes for the winning team!
+
+Rules:
+- Max team size: 6
+- Don't interfere with other teams' code.
+- No offensive imagery in games.
+- Use of third-party assets is fine but must be declared and will not be taken into account in judging
+
+Contact us in advance if you want any hardware provided. No promises that we can get anything though.
+

--- a/_events/2019_11_27_Graphcore_ai.md
+++ b/_events/2019_11_27_Graphcore_ai.md
@@ -1,0 +1,20 @@
+---
+layout: event
+published: true
+title: AI algorithms for large scale machines by Graphcore
+date:     2019-11-27 13:00:00 +0000
+date_end: 2019-11-27 14:00:00 +0000
+banner: 2019_11_27_Graphcore_ai.png
+location: Queens 1.6 SLT
+fb_link: https://www.facebook.com/events/418489025723362/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: Graphcore
+---
+
+Our IPU accelerators and Poplar software together make the fastest and most flexible platform for current and future machine intelligence applications.
+
+Hear directly from Luke Hudlass-Galley, University of Bristol Graduate and Research Engineer at Graphcore, about the company and his work designing AI algorithms for large scale machines

--- a/_events/2019_11_28_Triangle_Crawl.md
+++ b/_events/2019_11_28_Triangle_Crawl.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: Triangle Crawl
+date:     2019-11-27 20:00:00 +0000
+date_end: 2019-11-28 04:00:00 +0000
+banner: 2019_11_28_Triangle_Crawl.png
+location: The White Harte
+fb_link: https://www.facebook.com/events/498914097363899/
+ticket_link: https://www.bristolsu.org.uk/groups/computer-science-society/events/triangle-crawl
+price: £3-5
+category:
+    - Social
+---
+
+Come along to the first CSS Bar Crawl of the Year! Provisional schedule: The White Harte (20:00) -> Berkeley Spoons (20:45) -> Brass Pig (21:30) -> Mbargo (22:15) -> Lola Lo (23:00)

--- a/_events/2019_11_28_css_lv_power_of_data.md
+++ b/_events/2019_11_28_css_lv_power_of_data.md
@@ -1,0 +1,20 @@
+---
+layout: event
+published: true
+title: The power of Data Science by LV=
+date:     2019-11-28 13:00:00 +0000
+date_end: 2019-11-28 14:00:00 +0000
+banner: 2019_11_28_css_lv_power_of_data.png
+location: Quuens 1.15 SLT
+fb_link: https://www.facebook.com/events/574368899802299/
+ticket_link:
+price: Free
+category:
+  - Tech Talk
+cohost:
+  - company: LV=
+---
+
+LV=GI's data science team utilises machine learning across its general insurance arms, focusing on car, home, pet, and travel insurance.
+From combating fraud to improving our processes, we know that machine learning and artificial intelligence will shape the future of our business, ensuring we're able to provide the best service possible for our customers.
+Members of the data science team will present examples of our live machine learning models used today by the business.

--- a/_events/2019_11_29_tree_dec.md
+++ b/_events/2019_11_29_tree_dec.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: Decorating MVB's Christmas Tree
+date:     2019-11-29 13:00:00 +0000
+date_end: 2019-11-29 14:00:00 +0000
+banner: 2019_11_29_tree.jpg
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/526306778216890/
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Join us to decorate the big Christmas tree that will be housed in the Atrium during holiday season! If you'd like to help make ornaments join bees in the hackspace on Thursday evening: https://www.facebook.com/events/832889900447004/

--- a/_events/2019_12_03_bpuzzled.md
+++ b/_events/2019_12_03_bpuzzled.md
@@ -1,0 +1,32 @@
+---
+layout: event
+published: true
+title: BPuzzled - Bloomberg Logic Puzzle
+date:     2019-12-03 18:00:00 +0000
+date_end: 2019-12-03 20:00:00 +0000
+banner: 2019_12_03_bpuzzled.jpg
+location: Bill Brown Suite, Queens
+fb_link: https://www.facebook.com/events/2522337001421339/
+ticket_link: bit.ly/bpuzzled-sign-up
+price: Free
+category:
+    - Competition
+cohost:
+  - company: Bloomberg
+---
+
+Bloomberg invites you to compete in our brand new puzzle competition - BPUZZLED!
+
+Created by Bloomberg Engineers, BPUZZLED is a competition where teams of up to four use creativity and teamwork to solve logic puzzles themed to cities around the world. The winning team will be flown to London to compete in the global finals. Come along to participate in some friendly competition and race to the finish!
+
+Participants will only need a laptop and a competitive spirit to take part. Remember to sign up here:
+
+bit.ly/bpuzzled-sign-up
+
+We look forward to seeing you there!
+
+<hr/>
+
+The theme of the puzzle hunt is Race to New York/London, where the puzzlers will start with 3 unlocked puzzles to solve.
+
+Each solved puzzle will unlock a new one. There is a total number of 8 puzzles and one meta puzzle which uses the answers from the other 8 puzzles. The first team to solve the meta puzzle is the winning team.

--- a/_events/2019_12_11_MVBall.md
+++ b/_events/2019_12_11_MVBall.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: MVBall - BEEESxCSS
+date:     2019-12-10 19:00:00 +0000
+date_end: 2019-12-10 23:00:00 +0000
+banner: 2019_12_11_MVBall.png
+location: The Bristol Hotel
+fb_link: https://www.facebook.com/events/531623697623198/
+ticket_link:
+price: £25-35
+category:
+    - Social
+cohost:
+  - company: BEEES
+---
+
+Fancy a night of wine, fine dining, getting smashed in suits and hammered in heels?
+Click GOING to receive updates!
+
+Your ticket will include a welcome drink on arrival, a three course meal, half a bottle of wine plus hot drinks and treats.
+There will also be a DJ for the duration of the evening plus a photographer at the venue to capture the moment 😊
+
+Dress Code: Black tie
+Location: The Bristol Hotel

--- a/_events/2019_12_11_MVBall_after_party.md
+++ b/_events/2019_12_11_MVBall_after_party.md
@@ -1,0 +1,22 @@
+---
+layout: event
+published: true
+title: MVBall after party
+date:     2019-12-10 23:00:00 +0000
+date_end: 2019-12-11 04:00:00 +0000
+banner: 2019_12_11_MVBall_after_party.png
+location: Lola Lo
+fb_link: https://www.facebook.com/events/422590671743135/
+ticket_link:
+price: £5
+category:
+    - Social
+cohost:
+  - company: BEEES
+---
+
+Official MVBall After Party!!
+
+We will be heading straight to Lola lo from The Bristol Hotel at 12!
+
+Make sure you mention you're with BEEES on the door - the more members we get the more free drinks we can give out!

--- a/_events/2019_12_13_roller_disco.md
+++ b/_events/2019_12_13_roller_disco.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: CSS does Roller Disco
+date:     2019-12-13 19:00:00 +0000
+date_end: 2019-12-13 22:00:00 +0000
+banner: 2019_12_13_roller_disco.png
+location: Millenium Square
+fb_link: https://www.facebook.com/events/538472593370280/
+ticket_link: http://www.bumpclub.co.uk/event/2019-11-22-2-2019-12-13/
+price: £10
+category:
+    - Social
+---
+
+Join us at the roller disco in Millenium Square for two hours of fun!

--- a/_events/2019_12_17_xmas_movie_night.md
+++ b/_events/2019_12_17_xmas_movie_night.md
@@ -1,0 +1,20 @@
+---
+layout: event
+published: true
+title: Xmas Movie night
+date:     2019-12-17 17:30:00 +0000
+date_end: 2019-12-17 21:30:00 +0000
+banner: 2019_12_17_xmas_movie_night.jpg
+location: Queens 1.15 SLT
+fb_link: https://www.facebook.com/events/478460012789277/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+    - CSS
+    - Matrix
+---
+
+Join us to watch Home Alone in Queens 1.15 (Small lecture theater).
+Popcorn will be provided!

--- a/_events/2020_01_24_drinks.md
+++ b/_events/2020_01_24_drinks.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: true
+title: A well earned pint | end of exam drinks at the Berkley
+date:     2020-01-24 19:00:00 +0000
+date_end: 2020-01-24 23:00:00 +0000
+banner: 2020_01_24_drinks.png
+location: The Berkley Weatherspoons
+fb_link: https://www.facebook.com/events/651890938682791
+ticket_link:
+price: Free
+category:
+    - Social
+---
+
+Join us for a well earned pint at The White Harte to celebrate the end of exams and then may even go out O,o

--- a/_events/2020_01_28_visa.md
+++ b/_events/2020_01_28_visa.md
@@ -1,0 +1,23 @@
+---
+layout: event
+published: true
+title: Who's Visa? | Networking event with VISA
+date:     2020-01-28 13:00:00 +0000
+date_end: 2020-01-28 14:00:00 +0000
+banner: 2020_01_28_visa.png
+location: MVB 1.11/1.11(A)
+fb_link: https://www.facebook.com/events/2455044068078277
+ticket_link:
+price: Free
+category:
+    - Networking
+cohost:
+  - company: VISA
+---
+
+Visa are going to do a talk on:
+- What Visa does
+- The technology they use
+- Internship opportunities
+- A Hackathon they're running
+- And an opportunity to network with software engineers at Visa

--- a/_events/2020_02_04_forensics_immersive.md
+++ b/_events/2020_02_04_forensics_immersive.md
@@ -1,0 +1,16 @@
+---
+layout: event
+published: false
+title: Digital forensics with Immersive labs
+date:     2020-02-24 17:00:00 +0000
+date_end: 2020-02-24 17:30:00 +0000
+banner: 2020_02_04_forensics_immersive.png
+location: TBC
+fb_link: https://www.facebook.com/events/204770640649660/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+Immersive Labs are doing a talk on digital forensics

--- a/_events/2020_02_05_board_games_with_beees.md
+++ b/_events/2020_02_05_board_games_with_beees.md
@@ -1,0 +1,18 @@
+---
+layout: event
+published: true
+title: CSS vs BEEES board game afternoon
+date:     2020-02-05 13:00:00 +0000
+date_end: 2020-02-05 17:00:00 +0000
+banner: 2020_02_05_board_games.png
+location: MVB
+fb_link: https://www.facebook.com/events/543324066391389/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+    - company: BEEES
+---
+
+Weather it's cards against humanity or monopoly join us as we take over MVB with our BEEES friends!

--- a/_events/2020_02_10_coffee.md
+++ b/_events/2020_02_10_coffee.md
@@ -1,0 +1,25 @@
+---
+layout: event
+published: true
+title: Coffee, Cake, and Community
+date:     2020-02-10 13:00:00 +0000
+date_end: 2020-02-10 14:00:00 +0000
+banner: 2020_02_10_coffee.jpg
+location: Bill Brown Suite Atrium
+fb_link: https://www.facebook.com/events/1574824675988917/
+ticket_link:
+price: Free
+category:
+  - Networking
+cohost:
+  - Bristol Engineering Design Society
+  - CSS
+  - Engineers Without Borders Bristol (EWB)
+  - Innovation Design Bristol
+  - University of Bristol Women in STEM Society
+  - Women in Engineering Bristol
+---
+
+Come for free cake and coffee provided by the Engineering Faculty! Coffee, Cake and Community will be a monthly event aimed at gathering BAME, LGBTQ+ and international engineers and allowing them to discuss their experiences over cake and coffee.
+
+All are welcome!

--- a/_events/2020_02_11_hack_ml.md
+++ b/_events/2020_02_11_hack_ml.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: Tricking Binary Trees - The (in)securities of ML
+date:     2020-02-11 13:00:00 +0000
+date_end: 2020-02-11 14:00:00 +0000
+banner: 2020_02_11_hack_ml.png
+location: Queens 1.15
+fb_link: https://www.facebook.com/events/188679032277673
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+---
+
+Joe Gardner from the Cyber Security practice and runner of Bristol Ethical Hackers is giving a talk on hacking ML.
+
+Abstract:
+Machine learning (ML) has become a topic of importance in the cyber security space over recent years, with numerous products being developed featuring ML algorithms to aid in attack detection. By introducing ML into systems, they become smarter and better at detecting attacks.
+However, one thing that is often overlooked when deploying ML in security applications is the robustness of the algorithm itself. Frequently, existing algorithms and frameworks are used which were not developed with an adversary in mind. What happens if an attacker doesn't want to be classified?
+In this talk I will provide an overview of the current academic space in attacking ML algorithms, and discuss some of the approaches that can be made to make ML more secure in the face of an adversary.

--- a/_events/2020_02_20_hash_code.md
+++ b/_events/2020_02_20_hash_code.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: CSS does Google Hash Code
+date:     2020-02-20 17:30:00 +0000
+date_end: 2020-02-20 21:30:00 +0000
+banner: 2020_02_20_hash_code.png
+location: Queens 1.7
+fb_link: https://www.facebook.com/events/209000613565626/
+ticket_link: https://codingcompetitions.withgoogle.com/hashcode
+price: Free
+category:
+    - Competition
+cohost:
+  - company: Google
+---
+
+Join us as we tackle this year's Google Hash Code
+- Bring a laptop
+- Sign up/more info: https://codingcompetitions.withgoogle.com/hashcode
+- Registration closes Feb 17 2020, 11:00

--- a/_events/2020_02_24_graphics.md
+++ b/_events/2020_02_24_graphics.md
@@ -1,0 +1,17 @@
+---
+layout: event
+published: true
+title: Computer Graphics with Carl
+date:     2020-02-24 13:00:00 +0000
+date_end: 2020-02-24 14:00:00 +0000
+banner: 2020_02_24_graphics.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/763788304146778/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+---
+
+Carl is giving a talk on cool projects he's done around computer graphics

--- a/_events/2020_02_27_bar_crawl.md
+++ b/_events/2020_02_27_bar_crawl.md
@@ -1,0 +1,24 @@
+---
+layout: event
+published: true
+title: I just want SAFE back the Bar Crawl
+date:     2020-02-27 20:00:00 +0000
+date_end: 2020-02-28 04:00:00 +0000
+banner: 2020_02_27_bar_crawl.png
+location: Steam -> Lounge
+fb_link: https://www.facebook.com/events/542952666308438/
+ticket_link: http://bit.ly/SAFEbarcrawl
+price: £5.00
+category:
+    - Social
+cohost:
+  - company: BEEES
+---
+
+It's been a term without SAFE - a term of painful uploads and hard to find results. Let's run about Bristol and drown our tears out by visiting the best Pubs in town along a magical Bris Crawl route!
+
+- Tickets: http://bit.ly/SAFEbarcrawl
+- Route: Steam, 8:15pm -> W. G. Grace, 9:00pm -> Brass Pig, 9:45pm --> Berkley, 10:30pm -> Lounge, 11:15pm
+- Date: 27th Feb
+- Time: 8pm
+- T-shirts will be handed out a couple days before the event

--- a/_events/2020_02_29_bris_hack_20.md
+++ b/_events/2020_02_29_bris_hack_20.md
@@ -1,0 +1,29 @@
+---
+layout: event
+published: true
+title: Bris Hack 20
+date:     2020-02-29 11:00:00 +0000
+date_end: 2020-03-01 14:00:00 +0000
+banner: 2020_02_29_bris_hack_20.png
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/576136016567399
+ticket_link: bit.ly/brishack2020
+price: Free
+category:
+    - Competition
+cohost:
+  - company: Boeing
+---
+
+Another year another 24hrs to build something great with other talented people in teams of 5. With access to the hack space it'll be a wonder how teams will exceed the brief.
+
+Tickets: bit.ly/brishack2020
+Theme: Urban Air Mobility
+Prizes: TBA
+
+Open to any current university student
+
+Pizza will be provided around 7pm and breakfast at 8am.
+Sleeping areas will be provided.
+
+Thanks to Boeing for making this event possible.

--- a/_events/2020_03_04_coffee_chocolate_code.md
+++ b/_events/2020_03_04_coffee_chocolate_code.md
@@ -1,0 +1,18 @@
+---
+layout: event
+published: true
+title: Coffee, Chocolate, and Code
+date:     2020-03-04 14:00:00 +0000
+date_end: 2020-03-04 17:00:00 +0000
+banner: 2020_03_04_coffee_chocolate_code.png
+location: Mrs Potts Chocolate House
+fb_link: https://www.facebook.com/events/525180921745706/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+Join us in Explore week to bash out some code and get ahead on coursework in Mrs Potts chocolate cafe!
+
+Bring a laptop

--- a/_events/2020_03_04_joint_opts.md
+++ b/_events/2020_03_04_joint_opts.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: Joint Honours Yr 2&3 optional choices
+date:     2020-03-04 13:00:00 +0000
+date_end: 2020-03-04 14:00:00 +0000
+banner: 2020_03_04_joint_opts.png
+location: MVB 1.15
+fb_link: https://www.facebook.com/events/815802905571252/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - SCHEEEM
+---
+For all Joint honour computer science students (Maths & CS; CS & Electronics; CS with innovation)
+
+Find out what optional units you can take with the new course changes
+
+Questions? Email: [sarah.connolly@bristol.ac.uk](mailto:sarah.connolly@bristol.ac.uk)

--- a/_events/2020_03_06_board_games.md
+++ b/_events/2020_03_06_board_games.md
@@ -1,0 +1,17 @@
+---
+layout: event
+published: true
+title: CSS does Board Games
+date:     2020-03-06 10:00:00 +0000
+date_end: 2020-03-06 17:00:00 +0000
+banner: 2020_03_06_board_games.jpg
+location: MVB Atrium
+fb_link: https://www.facebook.com/events/505556233679958/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Come to MVB with friends and play board games with us! Board games provided :D

--- a/_events/2020_03_09_yr2_opts.md
+++ b/_events/2020_03_09_yr2_opts.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: Optional choices for current yr2 CS
+date:     2020-03-09 09:30:00 +0000
+date_end: 2020-03-09 10:30:00 +0000
+banner: 2020_03_09_yr2_opts.png
+location: MVB 2.11
+fb_link: https://www.facebook.com/events/182902252993210/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - SCHEEEM
+---
+For all current year 2 computer science students (BSc & MEng)
+
+Find out what optional units you can take with the new course changes
+
+Questions? Email: [sarah.connolly@bristol.ac.uk](mailto:sarah.connolly@bristol.ac.uk)

--- a/_events/2020_03_09_yr3_opts.md
+++ b/_events/2020_03_09_yr3_opts.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+title: Optional choices for current yr3 MEng
+date:     2020-03-09 13:00:00 +0000
+date_end: 2020-03-09 14:00:00 +0000
+banner: 2020_03_09_yr3_opts.png
+location: MVB 1.11
+fb_link: https://www.facebook.com/events/188798842379219/
+ticket_link:
+price: Free
+category:
+    - Tech Talk
+cohost:
+    - SCHEEEM
+---
+For all current MEng yr 3 students
+
+Find out what optional units you can take with the new course changes
+
+Questions? Email: [sarah.connolly@bristol.ac.uk](mailto:sarah.connolly@bristol.ac.uk)

--- a/_events/2020_03_17_standup.md
+++ b/_events/2020_03_17_standup.md
@@ -1,0 +1,21 @@
+---
+layout: event
+published: true
+cancelled: true
+cancel_reason: Due to Corona virus, we're cancelling this event
+title: Stand up comedy night
+date:     2020-03-17 18:00:00 +0000
+date_end: 2020-03-17 20:00:00 +0000
+banner: 2020_03_17_standup.png
+location: The White Rabbit
+fb_link: https://www.facebook.com/events/198717288139590/
+ticket_link:
+price: Free
+category:
+    - Social
+cohost:
+---
+
+Join us for a night of laughs as members of the CS department brave the stage for your entertainment.
+
+Hosted at the White Rabbit so you can enjoy comedy whilst having a delicious slice of pizza 🍕🍕🍕

--- a/_events/2020_03_25_minecraft.md
+++ b/_events/2020_03_25_minecraft.md
@@ -1,0 +1,41 @@
+---
+layout: event
+published: true
+cancelled: false
+cancel_reason:
+title: CSS plays Minecraft
+date:     2020-03-20 13:00:00 +0000
+date_end: 2020-05-24 01:00:00 +0000
+banner: 2020_03_25_minecraft.png
+location: mc.cssbristol.co.uk
+fb_link: https://www.facebook.com/events/2554547364861901
+ticket_link: https://forms.gle/vaGvMCKPmMzsBM3w9
+price: Free
+category:
+    - Social
+cohost:
+---
+## That's all folks
+We've had a good run building, farming, and socialising but as with all great things there comes an end 😢
+
+We've slain the Ender Dragon and hosted our AGM in the MVB (Minecraft Ventures Building)
+
+But don't worry you're work has not been wasted. You can download the world [here](https://drive.google.com/file/d/1YBXUcCRvF-c4AQkl2nOdWEgct8oMJY_E/view?usp=sharing)
+
+---
+Corona Virus has all of us bored - lets stay social and play Minecraft together!
+
+Join us on our Minecraft server at mc.cssbristol.co.uk
+
+~~Sign up to the server [here](https://forms.gle/vaGvMCKPmMzsBM3w9)~~ *whitelist now disabled*
+
+Make sure you join the Discord server [here](https://discord.gg/nYwbhf8)
+
+Any problems email: [webmaster@cssbristol.co.uk](mailto:webmaster@cssbristol.co.uk)
+
+## Rules
+1. Don't be a dick
+2. Don't steal
+3. Don't grief
+4. Be nice
+5. Have fun


### PR DESCRIPTION
This reverts commit 2c7baaa970297b7c7dc9209bc065725aa43618a5.

Events should be left as an archive of what has happened for several reasons:
1. Future committees can get inspiration for events
2. Students can see what CSS offers
3. Companies can see what events have happened for inspiration
4. Companies can determine if it is worth sponsoring the society based on how active the society is
