### PR TITLE
Add group chat invitation links to website

### DIFF
--- a/pages/group-chats/index.md
+++ b/pages/group-chats/index.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Group Chats
+permalink: /groups/
+show-in-nav: false
+---
+
+# CSS Cohort Group Chats
+These URLs require you to be signed in to your University outlook account. This is to prevent spammers from outside the University from joining. **Please do not share the raw invitation URL with anyone.**
+
+**First Year UG:** []
+
+**Second Year UG:**
+
+**Third Year UG**
+
+**Postgraduate Conversion**: 

--- a/pages/group-chats/index.md
+++ b/pages/group-chats/index.md
@@ -8,10 +8,8 @@ show-in-nav: false
 # CSS Cohort Group Chats
 These URLs require you to be signed in to your University outlook account. This is to prevent spammers from outside the University from joining. **Please do not share the raw invitation URL with anyone.**
 
-**First Year UG:** []
-
-**Second Year UG:**
-
-**Third Year UG**
-
-**Postgraduate Conversion**: 
+* [First Year UG](/groups/year-1)
+* [Second Year UG](/groups/year-2)
+* [Third Year UG](/groups/year-3)
+* [Fourth Year UG](/groups/year-4)
+* Postgraduate Conversion (Coming Soon)

--- a/pages/group-chats/year-1.md
+++ b/pages/group-chats/year-1.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Freshers Group Chat
+permalink: /groups/year-1/
+redirect_to: https://chat.whatsapp.com/IeqC6wKr80CJmnlVWk4nnv
+show-in-nav: false
+---

--- a/pages/group-chats/year-2.md
+++ b/pages/group-chats/year-2.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Second Year Group Chat
+permalink: /groups/year-2/
+redirect_to: https://uob.sharepoint.com/:u:/t/grp-CSSCommittee213/EcmLsA8wmadKvjtqAt9gkJUBa4yeRA8zDu35nvTl2kE0Zw?e=89kqCR
+show-in-nav: false
+---
+

--- a/pages/group-chats/year-3.md
+++ b/pages/group-chats/year-3.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Third Year Group Chat
+permalink: /groups/year-3/
+redirect_to: https://uob.sharepoint.com/:u:/t/grp-CSSCommittee213/EeOxcMmOrNhJos7Ivp4q8Z4B7HMaqWiooWRBAmMdnNfF1Q?e=gzaUrl
+show-in-nav: false
+---
+

--- a/pages/group-chats/year-4.md
+++ b/pages/group-chats/year-4.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Fourth Year Group Chat
+permalink: /groups/year-4/
+redirect_to: https://uob.sharepoint.com/:u:/t/grp-CSSCommittee213/EcpgcZx3yT1PmNAJQ0vzdB4Bjg0drgoPi1xlyX2Ao3ps6w?e=1FSSZO
+show-in-nav: false
+---


### PR DESCRIPTION
* Creates `/groups/` page with links to
   * `/groups/year-1/` - redirects to whatsapp invitation link
   * `/groups-year-2/` - redirects to SharePoint link viewable only to UoB members; once signed in, redirects to whatsapp link.
   * ^ same for the rest of the years