### PR TITLE
Enable contact form on sponsorship page

### DIFF
--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -1,22 +1,22 @@
-<form class="contact-form">
+<form class="contact-form" id="sponsorship-contact-form">
     <div class="row">
         <div class="input-group half-cols left-col" id="name-group">
             <label for="name">Name *</label>
-            <input type="text" placeholder="Your name" id="name" name="name" />
+            <input type="text" placeholder="Your name" id="name" name="name" required />
         </div>
         <div class="input-group half-cols right-col" id="position-group">
             <label for="position">Position *</label>
-            <input type="text" placeholder="E.g. 'Campus recruiter'" id="position" name="position" />
+            <input type="text" placeholder="E.g. 'Campus recruiter'" id="position" name="jobPosition" required />
         </div>
     </div>
     <div class="row">
         <div class="input-group two-cols left-col" id="company-group">
             <label for="company">Company name *</label>
-            <input type="text" placeholder="Your company name" id="company" name="company" />
+            <input type="text" placeholder="Your company name" id="company" name="companyName" required />
         </div>
         <div class="input-group two-cols right-col" id="budget-group">
             <label for="budget">Budget *</label>
-            <select name="budget" id="budget">
+            <select name="budget" id="budget" required>
                 <option disabled selected>Select from dropdown</option>
                 <option>Less than £200</option>
                 <option>£200-499</option>
@@ -32,31 +32,33 @@
     <div class="row">
         <div class="input-group left-col" id="email-group">
             <label for="email">Email address *</label>
-            <input type="email" placeholder="example@example.com" id="email" name="email" />
+            <input type="email" placeholder="example@example.com" id="email" name="emailAddr" required/>
         </div>
         <div class="input-group left-col" id="tel-group">
             <label for="tel">Telephone</label>
-            <input type="tel" placeholder="(+44) ##### #####" id="tel" name="tel" />
+            <input type="tel" placeholder="(+44) ##### #####" id="tel" name="telNum" />
         </div>
     </div>
     <div class="row">
         <div class="input-group left-col" id="interest-group">
             <label for="interest">I'm interested in</label>
-            <select name="interest" id="interest">
+            <select name="interestedIn" id="interest" required>
                 <option disabled selected>Select from dropdown</option>
                 <option>A year-long sponsorship</option>
                 <option>A tech-talk</option>
                 <option>Hackathon or Game-jam</option>
                 <option>Custom event</option>
                 <option>Outreach</option>
+                <option>Other (please specify in message below)</option>
             </select>
         </div>
     </div>
     <div class="row">
         <div class="input-group left-col" id="message-group">
             <label for="message">Message *</label>
-            <textarea rows="12" cols="80" id="message" name="message"></textarea>
+            <textarea rows="12" cols="80" id="message" name="message" required></textarea>
         </div>
     </div>
     <input type="submit" value="Send" class="btn dark" />
+    <div id="sponsorship-form-feedback"></div>
 </form>

--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -17,7 +17,7 @@
         <div class="input-group two-cols right-col" id="budget-group">
             <label for="budget">Budget *</label>
             <select name="budget" id="budget" required>
-                <option disabled selected>Select from dropdown</option>
+                <option disabled selected value="">Select from dropdown</option>
                 <option>Less than £200</option>
                 <option>£200-499</option>
                 <option>£500-999</option>
@@ -43,7 +43,7 @@
         <div class="input-group left-col" id="interest-group">
             <label for="interest">I'm interested in</label>
             <select name="interestedIn" id="interest" required>
-                <option disabled selected>Select from dropdown</option>
+                <option disabled selected value="">Select from dropdown</option>
                 <option>A year-long sponsorship</option>
                 <option>A tech-talk</option>
                 <option>Hackathon or Game-jam</option>

--- a/_layouts/sponsor.html
+++ b/_layouts/sponsor.html
@@ -167,21 +167,21 @@ layout: bare
                     <a href="mailto:president@cssbristol.co.uk">president@cssbristol.co.uk</a> or
                     <a href="mailto:vice-president@cssbristol.co.uk">vice-president@cssbristol.co.uk</a>.
                 </p>
-
-
-                {% comment %}
-                ================================================
-                UNCOMMENT THIS WHEN BACK-END FORM HANDLING ADDED
-                remember to also uncomment horse background
-                ================================================
-                <p>Drop us a note by filling in the form below. Alternatively, you can send an email to
-                    <a href="mailto:president@cssbristol.co.uk">president@cssbristol.co.uk</a> or
-                    <a href="mailto:vice-president@cssbristol.co.uk">vice-president@cssbristol.co.uk</a>.
+                
+                <p>Drop us a note by filling in the form below. Alternatively, you can email to
+                    <a href="mailto:sponsorship@cssbristol.co.uk">sponsorship@cssbristol.co.uk</a>
                 </p>
 
                 <p>Thank you for your interest!</p>
+                <noscript>
+                    The contact form requires Javascript to be enabled. Please contact us by email instead.
+                    <style>
+                        #sponsorship-contact-form {
+                            display: none;
+                        }
+                    </style>
+                </noscript>
                 {% include contact-form.html %}
-                {% endcomment %}
             </div>
         </section>
     </div>

--- a/_layouts/sponsor.html
+++ b/_layouts/sponsor.html
@@ -163,11 +163,6 @@ layout: bare
         <section class="section contact" id="contact">
             <div class="container narrow wrapper">
                 <h2 class="heading">Get in touch with us</h2>
-                <p>If you'd like to work with us, please get in touch with us by emailing
-                    <a href="mailto:president@cssbristol.co.uk">president@cssbristol.co.uk</a> or
-                    <a href="mailto:vice-president@cssbristol.co.uk">vice-president@cssbristol.co.uk</a>.
-                </p>
-                
                 <p>Drop us a note by filling in the form below. Alternatively, you can email to
                     <a href="mailto:sponsorship@cssbristol.co.uk">sponsorship@cssbristol.co.uk</a>
                 </p>

--- a/_layouts/sponsor.html
+++ b/_layouts/sponsor.html
@@ -189,5 +189,7 @@ layout: bare
 
   {% include sponsors.html %}
   <script src="/assets/scripts/sponsorshop-slider.js"></script>
+  <script src="/assets/scripts/contact-form-submit.js"></script>
+
     {% include footer.html %}
   

--- a/_sass/_sponsor.scss
+++ b/_sass/_sponsor.scss
@@ -467,7 +467,7 @@
 }
 
 .contact-form {
-    #sponsorship-form-feedback {
+    #sponsorship-form-feedback > div {
         font-weight: bold;
         background: linear-gradient(to left, $dark-pink, lighten($dark-purple, 10%));
         color: #fff;

--- a/_sass/_sponsor.scss
+++ b/_sass/_sponsor.scss
@@ -341,7 +341,7 @@
 
     .contact {
         margin-top: 12em;
-        // background-image: url('/assets/images/contrib/sponsorship-page/horse.svg');
+        background-image: url('/assets/images/contrib/sponsorship-page/horse.svg');
         background-repeat: no-repeat;
         background-size: contain;
         background-position: right bottom;
@@ -467,6 +467,12 @@
 }
 
 .contact-form {
+    #sponsorship-form-feedback {
+        font-weight: bold;
+        background: linear-gradient(to left, $dark-pink, lighten($dark-purple, 10%));
+        color: #fff;
+        padding: 1em;
+    }
     label {
         display: block;
         font-weight: 700;

--- a/_sass/_sponsor.scss
+++ b/_sass/_sponsor.scss
@@ -468,6 +468,7 @@
 
 .contact-form {
     #sponsorship-form-feedback > div {
+        margin-top: 2em;
         font-weight: bold;
         background: linear-gradient(to left, $dark-pink, lighten($dark-purple, 10%));
         color: #fff;

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -41,12 +41,13 @@ document.addEventListener("DOMContentLoaded", function () {
                 message,
             }),
         }).then(function(resp) {
+            // if response isn't 2xx
             if(resp.status < 200 && resp.status > 299) {
                 console.error(`${resp.status} response code returned.`)
+                formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
+            } else {
                 formFeedback.innerHTML = "<div>Your query has been passed on to our committee, who aim to reply as soon as possible.</div>";
                 form.target.reset();
-            } else {
-                formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
             }
         }).catch(function (e) {
             console.error(e);

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -41,7 +41,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 message,
             }),
         }).then(function(resp) {
-            if(resp.status >= 200 || resp.status < 300) {
+            if(resp.status < 200 && resp.status > 299) {
                 console.error(`${resp.status} response code returned.`)
                 formFeedback.innerHTML = "<div>Your query has been passed on to our committee, who aim to reply as soon as possible.</div>";
                 form.target.reset();

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -47,7 +47,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
             } else {
                 formFeedback.innerHTML = "<div>Your query has been passed on to our committee, who aim to reply as soon as possible.</div>";
-                form.target.reset();
+                form.reset();
             }
         }).catch(function (e) {
             console.error(e);

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
     const form = document.getElementById("sponsorship-contact-form");
     const formFeedback = document.getElementById("sponsorship-form-feedback");
-    if(!form) return;
+    if(!form) return false;
 
     form.addEventListener("submit", function (event) {
         event.preventDefault();
@@ -18,7 +18,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const requiredFields = [name, companyName, jobPosition, budget, emailAddr, telNum, interestedIn, message];
         if(requiredFields.find(val => !val)) {
             formFeedback.textContent = "Please fill in all required fields.";
-            return;
+            return false;
         }
 
         // uses MS PowerAutomate workflow for back-end processing
@@ -45,5 +45,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 formFeedback.textContent = "An unexpected error occurred. Please contact us by email instead.";
             }
         });
+
+        return false;
     });
 });

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -42,12 +42,14 @@ document.addEventListener("DOMContentLoaded", function () {
             }),
         }).then(function(resp) {
             if(resp.status >= 200 || resp.status < 300) {
+                console.error(`${resp.status} response code returned.`)
                 formFeedback.innerHTML = "<div>Your query has been passed on to our committee, who aim to reply as soon as possible.</div>";
                 form.target.reset();
             } else {
                 formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
             }
         }).catch(function (e) {
+            console.error(e);
             formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
         });
 

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -1,0 +1,49 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const form = document.getElementById("sponsorship-contact-form");
+    const formFeedback = document.getElementById("sponsorship-form-feedback");
+    if(!form) return;
+
+    form.addEventListener("submit", function (event) {
+        event.preventDefault();
+        const elements = event.target.elements;
+        const name = elements.name.value;
+        const companyName = elements.companyName.value;
+        const jobPosition = elements.jobPosition.value || "Unspecified";
+        const budget = elements.budget.value;
+        const emailAddr = elements.emailAddr.value;
+        const telNum = elements.telNum.value || "Unspecified";
+        const interestedIn = elements.interestedIn.value;
+        const message = elements.message.value;
+
+        const requiredFields = [name, companyName, jobPosition, budget, emailAddr, telNum, interestedIn, message];
+        if(requiredFields.find(val => !val)) {
+            formFeedback.textContent = "Please fill in all required fields.";
+            return;
+        }
+
+        // uses MS PowerAutomate workflow for back-end processing
+        const processingURL = "https://prod-139.westeurope.logic.azure.com:443/workflows/83671c3104be4329813f7b996418f427/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Sel8HbeYlcu_jZiXXEF2kq8YHJn7A9SfaI-lT1rjnWs";
+        fetch(processingURL, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                name,
+                companyName,
+                jobPosition,
+                budget,
+                emailAddr,
+                telNum,
+                interestedIn,
+                message,
+            }),
+        }).then(function(resp) {
+            if(resp.status >= 200 || resp.status < 300) {
+                formFeedback.textContent = "Your query has been passed on to our committee, who aim to reply as soon as possible";
+            } else {
+                formFeedback.textContent = "An unexpected error occurred. Please contact us by email instead.";
+            }
+        });
+    });
+});

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -42,7 +42,8 @@ document.addEventListener("DOMContentLoaded", function () {
             }),
         }).then(function(resp) {
             if(resp.status >= 200 || resp.status < 300) {
-                formFeedback.innerHTML = "<div>Your query has been passed on to our committee, who aim to reply as soon as possible</div>";
+                formFeedback.innerHTML = "<div>Your query has been passed on to our committee, who aim to reply as soon as possible.</div>";
+                form.target.reset();
             } else {
                 formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
             }

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -5,6 +5,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     form.addEventListener("submit", function (event) {
         event.preventDefault();
+
         const elements = event.target.elements;
         const name = elements.name.value;
         const companyName = elements.companyName.value;
@@ -44,6 +45,8 @@ document.addEventListener("DOMContentLoaded", function () {
             } else {
                 formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
             }
+        }).catch(function (e) {
+            formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
         });
 
         return false;

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
     const form = document.getElementById("sponsorship-contact-form");
     const formFeedback = document.getElementById("sponsorship-form-feedback");
+    console.log("SUBMITTED");
     if(!form) return false;
 
     form.addEventListener("submit", function (event) {

--- a/assets/scripts/contact-form-submit.js
+++ b/assets/scripts/contact-form-submit.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const requiredFields = [name, companyName, jobPosition, budget, emailAddr, telNum, interestedIn, message];
         if(requiredFields.find(val => !val)) {
-            formFeedback.textContent = "Please fill in all required fields.";
+            formFeedback.innerHTML = "<div>Please fill in all required fields.</div>";
             return false;
         }
 
@@ -40,9 +40,9 @@ document.addEventListener("DOMContentLoaded", function () {
             }),
         }).then(function(resp) {
             if(resp.status >= 200 || resp.status < 300) {
-                formFeedback.textContent = "Your query has been passed on to our committee, who aim to reply as soon as possible";
+                formFeedback.innerHTML = "<div>Your query has been passed on to our committee, who aim to reply as soon as possible</div>";
             } else {
-                formFeedback.textContent = "An unexpected error occurred. Please contact us by email instead.";
+                formFeedback.innerHTML = "<div>An unexpected error occurred. Please contact us by email instead.</div>";
             }
         });
 


### PR DESCRIPTION
There was meant to be a contact form on the sponsorship page; this was commented out until now because we didn't have a back-end, but I've discovered that MS PowerAutomate can process HTTP requests, so filling in the contact form will submit a http request to an MS PowerAutomate workflow.

Limitations:

- ~~This is on my account; there doesn't seem to be a way to do this on the Committee team, so the powerAutomate workflow may need to be re-created once I leave uni.~~ I've added the committee team as an owner; I hope this means that the flow will not be disabled when I leave uni.