### PR TITLE
Deploy to netlify with CRON

### DIFF
--- a/.github/workflows/netlify-deployment.yml
+++ b/.github/workflows/netlify-deployment.yml
@@ -1,8 +1,9 @@
-name: "Scheduled: Build and deploy jekyll site to Netlify"
+name: "Build and deploy jekyll site to Netlify"
 
 on:
   schedule:
     - cron: "0 6,13-15,18,22 * * *"
+  workflow_dispatch:
 
 jobs:
   jekyll:

--- a/.github/workflows/netlify-scheduled.yml
+++ b/.github/workflows/netlify-scheduled.yml
@@ -1,0 +1,67 @@
+name: "Scheduled: Build and deploy jekyll site to Netlify"
+
+on:
+  schedule:
+    - cron: "0 6,13-15,18,22 * * *"
+
+jobs:
+  jekyll:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📂 setup
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: 💎 setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2 # can change this to 2.7 or whatever version you prefer
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: 🔨 install dependencies & build site
+        uses: limjh16/jekyll-action-ts@v2
+        with:
+          enable_cache: true
+          ### Enables caching. Similar to https://github.com/actions/cache.
+          #
+          # format_output: true
+          ### Uses prettier https://prettier.io to format jekyll output HTML.
+          #
+          # prettier_opts: '{ "useTabs": true }'
+          ### Sets prettier options (in JSON) to format output HTML. For example, output tabs over spaces.
+          ### Possible options are outlined in https://prettier.io/docs/en/options.html
+          #
+          # prettier_ignore: 'about/*'
+          ### Ignore paths for prettier to not format those html files.
+          ### Useful if the file is exceptionally large, so formatting it takes a while.
+          ### Also useful if HTML compression is enabled for that file / formatting messes it up.
+          #
+          # jekyll_src: sample_site
+          ### If the jekyll website source is not in root, specify the directory. (in this case, sample_site)
+          ### By default, this is not required as the action searches for a _config.yml automatically.
+          #
+          # gem_src: sample_site
+          ### By default, this is not required as the action searches for a _config.yml automatically.
+          ### However, if there are multiple Gemfiles, the action may not be able to determine which to use.
+          ### In that case, specify the directory. (in this case, sample_site)
+          ###
+          ### If jekyll_src is set, the action would automatically choose the Gemfile in jekyll_src.
+          ### In that case this input may not be needed as well.
+          #
+          # key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          # restore-keys: ${{ runner.os }}-gems-
+          ### In cases where you want to specify the cache key, enable the above 2 inputs
+          ### Follows the format here https://github.com/actions/cache
+          #
+          # custom_opts: '--drafts --future'
+          ### If you need to specify any Jekyll build options, enable the above input
+          ### Flags accepted can be found here https://jekyllrb.com/docs/configuration/options/#build-command-options
+
+      - name: 🚀 Deploy to Netlify CDN
+        uses: netlify/actions/cli@master
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        with:
+          args: deploy --dir=_site --prod --message="${{ github.ref_name }}@${{ github.sha }}"
+          secrets: '["NETLIFY_AUTH_TOKEN", "NETLIFY_SITE_ID"]'


### PR DESCRIPTION
The admin panel is hosted on netlify (and needs to be to use Netlify Identity). This is to see if we can use GitHub actions to schedule deployments to netlify based on a CRON job. This way, we won't use up all of our netlify build minutes.

If this works, it might be worth moving the site hosting to netlify so that there aren't two versions of the website?