### PR TITLE
Allow absolute image paths in frontmatter

### DIFF
--- a/_includes/company_logo.html
+++ b/_includes/company_logo.html
@@ -9,10 +9,10 @@
   {% comment %}
     check if the url starts with "http://", "https://" or "/"; if it does then don't prepend the path ot the companies directory
   {% endcomment %}
-  {% assign checkHttpStart = c.logo | split: "http://" | first}
-  {% assign checkHttpsStart = c.logo | split: "https://" | first}
-  {% assign checkSlashStart = c.logo | split: "/" | first}
-  {% assign isRelative = checkHttpStart != blank or checkHttpsStart != blank or checkSlashStart != blank %}
+  {% assign checkHttpStart = c.logo | split: "http://" | first %}
+  {% assign checkHttpsStart = c.logo | split: "https://" | first %}
+  {% assign checkSlashStart = c.logo | split: "/" | first %}
+  {% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
   {% if isRelative %}
     {% assign imagePath = c.logo | prepend: "/assets/images/contrib/companies/" %}
   {% else %}

--- a/_includes/company_logo.html
+++ b/_includes/company_logo.html
@@ -6,8 +6,20 @@
   data-tooltip="{{ c.name }}"
   class="company-logo"
 >
+  {% comment %}
+    check if the url starts with "http://", "https://" or "/"; if it does then don't prepend the path ot the companies directory
+  {% endcomment %}
+  {% assign checkHttpStart = c.logo | split: "http://" | first}
+  {% assign checkHttpsStart = c.logo | split: "https://" | first}
+  {% assign checkSlashStart = c.logo | split: "/" | first}
+  {% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
+  {% if isRelative %}
+    {% assign imagePath = c.logo | prepend: "/assets/images/contrib/companies/" %}
+  {% else %}
+    {% assign imagePath = c.logo %}
+  {% endif %}
   <img
-    src="/assets/images/contrib/companies/{{ c.logo }}"
+    src="{{ imagePath }}"
     alt="{{ c.name }}"
     width="130"
     height="170"

--- a/_includes/company_logo.html
+++ b/_includes/company_logo.html
@@ -12,7 +12,7 @@
   {% assign checkHttpStart = c.logo | split: "http://" | first}
   {% assign checkHttpsStart = c.logo | split: "https://" | first}
   {% assign checkSlashStart = c.logo | split: "/" | first}
-  {% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
+  {% assign isRelative = checkHttpStart != blank or checkHttpsStart != blank or checkSlashStart != blank %}
   {% if isRelative %}
     {% assign imagePath = c.logo | prepend: "/assets/images/contrib/companies/" %}
   {% else %}

--- a/_includes/company_logo.html
+++ b/_includes/company_logo.html
@@ -12,9 +12,11 @@
   {% assign checkHttpStart = c.logo | split: "http://" | first %}
   {% assign checkHttpsStart = c.logo | split: "https://" | first %}
   {% assign checkSlashStart = c.logo | split: "/" | first %}
-  {% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
-  {% if isRelative %}
-    {% assign imagePath = c.logo | prepend: "/assets/images/contrib/companies/" %}
+  {% assign checkHttpStart = page.banner | split: "http://" | first %}
+  {% assign checkHttpsStart = page.banner | split: "https://" | first %}
+  {% assign checkSlashStart = page.banner | split: "/" | first %}
+  {% if checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
+      {% assign imagePath = c.logo | prepend: "/assets/images/contrib/companies/" %}
   {% else %}
     {% assign imagePath = c.logo %}
   {% endif %}

--- a/_includes/event_cards.html
+++ b/_includes/event_cards.html
@@ -1,8 +1,21 @@
+{% comment %}
+check if the url starts with "http://", "https://" or "/"; if it does then don't prepend the path ot the companies directory
+{% endcomment %}
+
+{% assign checkHttpStart = event.banner | split: "http://" | first %}
+{% assign checkHttpsStart = event.banner | split: "https://" | first %}
+{% assign checkSlashStart = event.banner | split: "/" | first %}
+{% if checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
+{% assign bannerPath = event.banner | prepend: "/assets/images/contrib/events/" %}
+{% else %}
+{% assign bannerPath = event.banner %}
+{% endif %}
+
 <div class="event-grid card-grid">
   {% for event in include.events %}
     <div class="card-grid__card{% if event.cancelled %} cancelled {% endif %}">
       {% if event.banner %}
-        <div class="card-grid__card__banner" style="background-image: url(/assets/images/contrib/events/{{ event.banner }});"></div>
+        <div class="card-grid__card__banner" style="background-image: url({{ bannerPath }});"></div>
       {% else %}
         <div class="card-grid__card__banner" style="background-image: url(/assets/images/core/default-event-banner.jpg);"></div>
       {% endif %}

--- a/_includes/event_cards.html
+++ b/_includes/event_cards.html
@@ -1,18 +1,18 @@
-{% comment %}
-check if the url starts with "http://", "https://" or "/"; if it does then don't prepend the path ot the companies directory
-{% endcomment %}
-
-{% assign checkHttpStart = event.banner | split: "http://" | first %}
-{% assign checkHttpsStart = event.banner | split: "https://" | first %}
-{% assign checkSlashStart = event.banner | split: "/" | first %}
-{% if checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
-{% assign bannerPath = event.banner | prepend: "/assets/images/contrib/events/" %}
-{% else %}
-{% assign bannerPath = event.banner %}
-{% endif %}
-
 <div class="event-grid card-grid">
   {% for event in include.events %}
+    {% comment %}
+      check if the url starts with "http://", "https://" or "/"; if it does then don't prepend the path ot the companies directory
+    {% endcomment %}
+
+    {% assign checkHttpStart = event.banner | split: "http://" | first %}
+    {% assign checkHttpsStart = event.banner | split: "https://" | first %}
+    {% assign checkSlashStart = event.banner | split: "/" | first %}
+    {% if checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
+     {% assign bannerPath = event.banner | prepend: "/assets/images/contrib/events/" %}
+    {% else %}
+      {% assign bannerPath = event.banner %}
+    {% endif %}
+
     <div class="card-grid__card{% if event.cancelled %} cancelled {% endif %}">
       {% if event.banner %}
         <div class="card-grid__card__banner" style="background-image: url({{ bannerPath }});"></div>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -2,6 +2,19 @@
 layout: default
 feed: "/feed/events.xml"
 ---
+{% comment %}
+check if the url starts with "http://", "https://" or "/"; if it does then don't prepend the path ot the companies directory
+{% endcomment %}
+
+{% assign checkHttpStart = page.banner | split: "http://" | first}
+{% assign checkHttpsStart = page.banner | split: "https://" | first}
+{% assign checkSlashStart = page.banner | split: "/" | first}
+{% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
+{% if isRelative %}
+{% assign bannerPath = page.banner | prepend: "/assets/images/contrib/companies/" %}
+{% else %}
+{% assign bannerPath = page.banner %}
+{% endif %}
 
 <section class="page-section">
   {% if page.cancelled %}
@@ -14,12 +27,13 @@ feed: "/feed/events.xml"
     {% endif %}
   </div>
   {% endif %}
+
   <article class="article extrawide event-page">
     <section>
       {% if page.banner %}
       <div
         class="event-page__banner"
-        style="background-image: url(/assets/images/contrib/events/{{ page.banner }});"
+        style="background-image: url({{ bannerPath }});"
       ></div>
       {% else %}
       <div

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -9,7 +9,7 @@ check if the url starts with "http://", "https://" or "/"; if it does then don't
 {% assign checkHttpStart = page.banner | split: "http://" | first}
 {% assign checkHttpsStart = page.banner | split: "https://" | first}
 {% assign checkSlashStart = page.banner | split: "/" | first}
-{% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
+{% assign isRelative = checkHttpStart != blank or checkHttpsStart != blank or checkSlashStart != blank %}
 {% if isRelative %}
 {% assign bannerPath = page.banner | prepend: "/assets/images/contrib/companies/" %}
 {% else %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -9,9 +9,14 @@ check if the url starts with "http://", "https://" or "/"; if it does then don't
 {% assign checkHttpStart = page.banner | split: "http://" | first}
 {% assign checkHttpsStart = page.banner | split: "https://" | first}
 {% assign checkSlashStart = page.banner | split: "/" | first}
-{% assign isRelative = checkHttpStart != blank or checkHttpsStart != blank or checkSlashStart != blank %}
+{% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
 {% if isRelative %}
 {% assign bannerPath = page.banner | prepend: "/assets/images/contrib/companies/" %}
+<!-- bannerPath: {{ bannerPath }} -->
+<!-- page.banner: {{ page.banner }} -->
+<!-- checkHttp: {{ checkHttpStart }} -->
+<!-- checkHttps: {{ checkHttpsStart }} -->
+<!-- checkSlash: {{ checkSlashStart }} -->
 {% else %}
 {% assign bannerPath = page.banner %}
 {% endif %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -6,9 +6,9 @@ feed: "/feed/events.xml"
 check if the url starts with "http://", "https://" or "/"; if it does then don't prepend the path ot the companies directory
 {% endcomment %}
 
-{% assign checkHttpStart = page.banner | split: "http://" | first}
-{% assign checkHttpsStart = page.banner | split: "https://" | first}
-{% assign checkSlashStart = page.banner | split: "/" | first}
+{% assign checkHttpStart = page.banner | split: "http://" | first %}
+{% assign checkHttpsStart = page.banner | split: "https://" | first %}
+{% assign checkSlashStart = page.banner | split: "/" | first %}
 {% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
 {% if isRelative %}
 {% assign bannerPath = page.banner | prepend: "/assets/images/contrib/companies/" %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -9,8 +9,7 @@ check if the url starts with "http://", "https://" or "/"; if it does then don't
 {% assign checkHttpStart = page.banner | split: "http://" | first %}
 {% assign checkHttpsStart = page.banner | split: "https://" | first %}
 {% assign checkSlashStart = page.banner | split: "/" | first %}
-{% assign isRelative = checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
-{% if isRelative %}
+{% if checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
 {% assign bannerPath = page.banner | prepend: "/assets/images/contrib/companies/" %}
 <!-- bannerPath: {{ bannerPath }} -->
 <!-- page.banner: {{ page.banner }} -->

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -10,12 +10,7 @@ check if the url starts with "http://", "https://" or "/"; if it does then don't
 {% assign checkHttpsStart = page.banner | split: "https://" | first %}
 {% assign checkSlashStart = page.banner | split: "/" | first %}
 {% if checkHttpStart != blank and checkHttpsStart != blank and checkSlashStart != blank %}
-{% assign bannerPath = page.banner | prepend: "/assets/images/contrib/companies/" %}
-<!-- bannerPath: {{ bannerPath }} -->
-<!-- page.banner: {{ page.banner }} -->
-<!-- checkHttp: {{ checkHttpStart }} -->
-<!-- checkHttps: {{ checkHttpsStart }} -->
-<!-- checkSlash: {{ checkSlashStart }} -->
+{% assign bannerPath = page.banner | prepend: "/assets/images/contrib/events/" %}
 {% else %}
 {% assign bannerPath = page.banner %}
 {% endif %}


### PR DESCRIPTION
Adds checks to see if a path given in frontmatter for a company logo or event banner is absolute or relative, and only prepends the path to the file if it is relative.